### PR TITLE
In response to the issue #32 Missing Social Media Handles Links 

### DIFF
--- a/index.html
+++ b/index.html
@@ -610,31 +610,31 @@
                 <ul class="social-list">
 
                   <li>
-                    <a href="#" class="social-link">
+                    <a href="https://www.facebook.com/" class="social-link">
                       <ion-icon name="logo-facebook"></ion-icon>
                     </a>
                   </li>
 
                   <li>
-                    <a href="#" class="social-link">
+                    <a href="https://twitter.com/?lang=en" class="social-link">
                       <ion-icon name="logo-twitter"></ion-icon>
                     </a>
                   </li>
 
                   <li>
-                    <a href="#" class="social-link">
+                    <a href="https://www.linkedin.com/" class="social-link">
                       <ion-icon name="logo-linkedin"></ion-icon>
                     </a>
                   </li>
 
                   <li>
-                    <a href="#" class="social-link">
+                    <a href="https://www.youtube.com/" class="social-link">
                       <ion-icon name="logo-youtube"></ion-icon>
                     </a>
                   </li>
 
                   <li>
-                    <a href="#" class="social-link">
+                    <a href="tel:+1234567890" class="social-link">
                       <ion-icon name="logo-whatsapp"></ion-icon>
                     </a>
                   </li>


### PR DESCRIPTION
I have Successfully linked the social media icons to the designated areas of interests. 
Changes
-  linked Instagram with Instagram page
-  linked Facebook with Facebook page
-  linked YouTube with YouTube page
-  linked X (formerly twitter) with X page
-  linked whatsapp to a number