### PR TITLE
fix: Title name of Login Page

### DIFF
--- a/login.html
+++ b/login.html
@@ -9,7 +9,7 @@
       href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css"
     />
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
-    <title>How to create Firebase login and register?</title>
+    <title>Login / SignUp</title>
     <link rel="stylesheet" href="login.css" />
   </head>
   <body>


### PR DESCRIPTION
## What Does This PR do?
 This PR fixes the title of login page from "How to create Firebase login and register?" -> "Login / SignUp" 
Fixes #159 

##How should this be Tested?
-[ ] Go to Home page
-[ ] Click on Login/Sign Up button 
-[ ] Check the page title text