### PR TITLE
Update footer copyright year to be dynamic

### DIFF
--- a/index.html
+++ b/index.html
@@ -793,7 +793,7 @@
     </div>
     <div class="footer-bottom">
       <p class="copyright">
-        &copy; 2024 All right reserved. Made with ❤ by Guardian Hackers.
+        &copy; <script>document.write(new Date().getFullYear())</script> All right reserved. Made with ❤ by Guardian Hackers.
       </p>
     </div>
   </footer>


### PR DESCRIPTION
Fixed issue #177 

This pull request updates the footer copyright year to be dynamically generated using JavaScript. The current year is now displayed automatically, ensuring that the year is always up-to-date without manual intervention. This improves the user experience by reflecting the current year in the copyright notice.
