### PR TITLE
navbar and footer icons fixed

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -967,7 +967,7 @@ footer {
   display: flex;
 
   flex: 1 0 0; /* Make the right part flexible */
-  justify-content: space-between; /* Distribute items evenly */
+  justify-content: space-evenly; /* Distribute items evenly */
 }
 .nav-links{
   
@@ -1007,7 +1007,10 @@ footer {
   font-size: 2rem;
   font-weight: 500;
 }
-
+.social-icons-container a {
+display: flex;
+margin: .8vmax 0 .8vmax 0;
+}
 .social-list {
   display: flex;
 }
@@ -1415,9 +1418,28 @@ footer {
   }
 }
 
+
+
+/* 
+responsiveness for small devices below 1200px */
+
+
+@media (max-width: 1200px) {
+  .navbar-list{
+    display: flex;
+    flex-direction: column !important;
+    justify-content: flex-start;
+    /* align-items: flex-start; */
+  }
+}
+
+
+
+
 /**
  * responsive for large than 1200px screen
  */
+
 
 @media (min-width: 1200px) {
   /**
@@ -1510,6 +1532,7 @@ footer {
 
 .icon {
   margin-right: 16px;
+
 }
 
 .icon.active {

--- a/index.html
+++ b/index.html
@@ -899,6 +899,7 @@
           </ul>
         </div>
         <div class="social-icons-container">
+          <h5>Follow us </h5>
           <a href="#">
             <div class="icon">
               <i class="fab fa-facebook-square"></i>


### PR DESCRIPTION
Navbar is now responsive for mobile and small devices with width less than 1200px. issue no. #313


**Before responsive** :- navbar elements are not visible completely in mobile devices , and footer icons are in different line and respective names are in different line.

![Screenshot 2024-05-14 080554](https://github.com/anuragverma108/SwapReads/assets/149225785/56e253a4-bf14-4005-ac6a-fcb15c6942b8)
![Screenshot 2024-05-14 082329](https://github.com/anuragverma108/SwapReads/assets/149225785/ccaacb49-7a8c-42e9-94aa-3a7bf6f521af)


**After responsive** :- now navbar is responsive to each device and footer icons will be in same line in which  respective names are.

![Screenshot 2024-05-14 084500](https://github.com/anuragverma108/SwapReads/assets/149225785/1ec45788-8727-4abf-b635-ed2d3128937d)
![Screenshot 2024-05-14 083613](https://github.com/anuragverma108/SwapReads/assets/149225785/2b01898f-0530-4464-a390-1c0801fe928c)

