### PR TITLE
Added transition to FAQ section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1543,6 +1543,7 @@ responsiveness for small devices below 1200px */
   color: var(--sonic-silver);
   max-height: 0;
   overflow: hidden;
+  transition: .4s ease-in-out;
 }
 /* 
 .answers.active {


### PR DESCRIPTION
I noticed that there is no transition used for the FAQ section, it just comes into view on click and disappears when clicked again. So I thought a transition for this would make the things feel better, and so I opened an issue and got assigned and I did the changes and here's the output -

Before
![SwapReads - Brave 2024-05-14 14-59-37 (1)](https://github.com/anuragverma108/SwapReads/assets/149924641/73c3223b-2a94-4760-abff-a97358be4785)


After
![SwapReads - Brave 2024-05-14 15-29-18](https://github.com/anuragverma108/SwapReads/assets/149924641/979550d1-abc2-4116-a5e6-befbfb8b1618)
