### PR TITLE
Border beam in the edges of the card upon Hover

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -644,13 +644,52 @@ body {
 \*-----------------------------------*/
 
 .chapter-card {
+  position: relative;
   height: 100%;
   background-color: var(--white);
   padding: 25px;
   border-radius: var(--radius-5);
   box-shadow: var(--shadow-2);
-  transition: var(--transition-2);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
+
+.chapter-card:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.chapter-card::before,
+.chapter-card::after {
+  content: '';
+  position: absolute;
+  width: 3px; /* Adjust the width of the beam as needed */
+  height: calc(100% + 6px); /* Extend the beam height to cover any card shadow */
+  background-color: var(--light-pink); /* Adjust the color of the beam */
+  transition: transform 0.3s ease;
+}
+
+.chapter-card::before {
+  top: 0;
+  left: 0;
+  transform-origin: top left;
+  transform: scaleY(0);
+}
+
+.chapter-card::after {
+  bottom: 0;
+  right: 0;
+  transform-origin: bottom right;
+  transform: scaleY(0);
+}
+
+.chapter-card:hover::before {
+  transform: scaleY(1) translateX(-50%); /* Move towards left */
+}
+
+.chapter-card:hover::after {
+  transform: scaleY(1) translateX(50%); /* Move towards right */
+}
+
 
 .chapter-card:is(:hover, :focus-within) {
   transform: translateY(-10px);


### PR DESCRIPTION
In the chapter-card class I added CSS code positions invisible lines (pseudo-elements) at the top-left and bottom-right corners of a card, and upon hovering, these lines extend outwards towards the left and right edges, creating a border beam effect. Pseudo

https://github.com/anuragverma108/SwapReads/assets/137412459/823c458d-5389-41dc-9008-f7c390a3d531

-elements (::before and ::after) are strategically placed at the corners of the card. Initially, they're invisible. When the card is hovered over, they become visible and elongate towards the left and right edges, creating a border beam effect. This transformation originates from the top-left and bottom-right corners, ensuring a visually appealing hover interaction.