### PR TITLE
Issue Number #389 solved (small bug of padding)

### DIFF
--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -295,7 +295,7 @@ label {
 }
 
 .close-icon {
-  margin-top: 2rem;
+  margin-top: 0.5rem;
   padding-left:92%;
 }
 

--- a/index.html
+++ b/index.html
@@ -725,7 +725,7 @@
           <p class="section-subtitle">Contact</p>
 
           <h2 class="h2 section-title has-underline">
-            Reach Out Below!
+            Reach Out Below
             <span class="span has-before"></span>
           </h2>
 

--- a/index.html
+++ b/index.html
@@ -725,7 +725,7 @@
           <p class="section-subtitle">Contact</p>
 
           <h2 class="h2 section-title has-underline">
-            Write me anything
+            Reach Out Below!
             <span class="span has-before"></span>
           </h2>
 


### PR DESCRIPTION
Previously: 
<img width="167" alt="image" src="https://github.com/anuragverma108/SwapReads/assets/86831838/b904dd51-55a9-4f24-b989-2ac0e2ca2805">

Now:
<img width="116" alt="image" src="https://github.com/anuragverma108/SwapReads/assets/86831838/2a942299-2117-42a5-9d82-baacb46111c1">

Fixed the small bug of the close icon not being appropriately set in frame when seen in dark mode on the login page.