### PR TITLE
Added alerts for invalid input in the price field, ISSUE #302

### DIFF
--- a/index.html
+++ b/index.html
@@ -501,7 +501,7 @@
 
       <label class="-label" for="yourPrice">Your Price (50% Off):</label>
       <div class="currency-container">
-      <label class="currency-label" for="currency">Currency:</label>
+      <label class="currency-label" for="currency">Currency: </label>
     <select id="currency" name="currency" class="input-field currency-select">
       
     <option value="INR">INR</option>
@@ -510,25 +510,54 @@
       <option value="GBP">GBP</option>
    </select>
     </div>
-      <input type="number" min="0" id="yourPrice" name="yourPrice" placeholder="Enter your desired selling price" required class="input-field">
+    <input type="number" id="yourPrice" name="yourPrice" placeholder="Enter your desired selling price" required class="input-field">
 
-
-              <label class="-label" for="yourPrice">Your Price (50% Off):</label>
-              <input type="number" id="yourPrice" name="yourPrice" placeholder="Enter your desired selling price"
-                required class="input-field">
-
-            </div>
+    <!-- Error message container -->
+    <span id="yourPrice-error" class="error"></span>
+</div>
 
             <button type="button" class="btn btn-primary exchange-form_btn" onclick="validateAndConnect()"></button>
           </div>
-
+          <script>
+            // Function to validate the price input
+            function validatePriceInput() {
+                var yourPriceInput = document.getElementById('yourPrice');
+                var yourPriceValue = yourPriceInput.value.trim();
+        
+                // Check if the price is a valid number
+                if (isNaN(yourPriceValue) || yourPriceValue === "") {
+                    // If not, display error message
+                    document.getElementById('yourPrice-error').textContent = "Please enter a valid number";
+                    // Change border color to red to indicate error
+                    yourPriceInput.style.borderColor = 'red';
+                } else {
+                    // If price is valid, clear error message and reset border color
+                    document.getElementById('yourPrice-error').textContent = "";
+                    yourPriceInput.style.borderColor = '';
+                }
+            }
+        
+            // Add event listener to validate price input on every input change
+            document.getElementById('yourPrice').addEventListener('input', validatePriceInput);
+        
+            // Function to validate and connect when the form is submitted
+            function validateAndConnect() {
+                // Trigger input validation before submitting the form
+                validatePriceInput();
+        
+                // Proceed with form submission only if price is valid
+                var errorElement = document.getElementById('yourPrice-error');
+                if (errorElement.textContent === "") {
+                    // If no error, proceed with further actions, such as form submission
+                    // Example: document.getElementById('yourForm').submit();
+                    alert("Form submitted successfully!");
+                }
+            }
+        </script>
+        
 
         </div>
       </section>
-
-
-
-
 
 
 

--- a/index.html
+++ b/index.html
@@ -488,18 +488,18 @@
 
           <div class="exchange-">
 
-            <div class="-fields">
+            <div class="form-fields">
 
-              <label class="-label" for="bookTitle">Book Title:</label>
+              <label class="form-label" for="bookTitle">Book Title:</label>
               <input type="text" id="bookTitle" name="bookTitle" placeholder="Enter the title of your book" required
                 class="input-field">
 
 
-              <label class="-label" for="bookAuthor">Author:</label>
+              <label class="form-label" for="bookAuthor">Author:</label>
               <input type="text" id="bookAuthor" name="bookAuthor" placeholder="Enter the author's name" required
                 class="input-field">
 
-      <label class="-label" for="yourPrice">Your Price (50% Off):</label>
+      <label class="form-label" for="yourPrice">Your Price (50% Off):</label>
       <div class="currency-container">
       <label class="currency-label" for="currency">Currency: </label>
     <select id="currency" name="currency" class="input-field currency-select">
@@ -510,7 +510,7 @@
       <option value="GBP">GBP</option>
    </select>
     </div>
-    <input type="number" id="yourPrice" name="yourPrice" placeholder="Enter your desired selling price" required class="input-field">
+    <input type="number" min="0" id="yourPrice" name="yourPrice" placeholder="Enter your desired selling price" required class="input-field">
 
     <!-- Error message container -->
     <span id="yourPrice-error" class="error"></span>
@@ -525,7 +525,7 @@
                 var yourPriceValue = yourPriceInput.value.trim();
         
                 // Check if the price is a valid number
-                if (isNaN(yourPriceValue) || yourPriceValue === "") {
+                if (isNaN(yourPriceValue) || yourPriceValue === "" || parseFloat(yourPriceValue) < 0) {
                     // If not, display error message
                     document.getElementById('yourPrice-error').textContent = "Please enter a valid number";
                     // Change border color to red to indicate error


### PR DESCRIPTION
### Description

Users are able to enter letters and symbols in the 'Your Price' section in 'Book Exchange Hub' under the Literary Realms Section. Only numbers should be allowed in this section, as even the currency can be selected above.

### Before

There was a lack of alert for entering letters, symbols and negative numbers in the price field. This made it unclear to the user about what type of input to follow. Even though it was not possible for the users to submit the form when having input other than numbers, no clarity was given on how to improve.

<img src="https://github.com/anuragverma108/SwapReads/assets/152146397/8221ba5a-35fa-4db3-9f7a-f3b12c8c8f24" alt="Before" width="400">

### After

Whenever a negative number or a letter or a symbol is added to the "Your Price" field, the lower border of the box becomes red and an alert saying "Please enter a valid number" pops up below the text box. 

<img src="https://github.com/anuragverma108/SwapReads/assets/152146397/ee41f679-9c26-4ab4-b781-a0dccb56f166" alt="Before" width="400">
<img src="https://github.com/anuragverma108/SwapReads/assets/152146397/a4719444-5560-4cfa-90e5-7212f74751b1" alt="Before" width="400">


Only valid number is allowed - 

<img src="https://github.com/anuragverma108/SwapReads/assets/152146397/bd378e45-7b34-4085-bdad-4412dd4e4199" alt="Before" width="400">

Therefore, extra clarity regarding the type of input is now being given to the user. This issue has been resolved. 

Thank you!

