### PR TITLE
Fix: Made text on testimonials appear when flipping.

### DIFF
--- a/assets/css/test-style.css
+++ b/assets/css/test-style.css
@@ -74,6 +74,14 @@
   background-color: hsl(357, 37%, 62%);
 }
 
+.dark-mode{
+
+  .backs{
+    background-color: black;
+  }
+
+}
+
 @media screen and (max-width: 768px) {
   .slide-content{
     margin: 0 10px;


### PR DESCRIPTION
Fixed issue #502 
I have fixed the issue in which text has not appeared when the testimonial card is flipped in dark mode.
Before change:
![Screenshot 2024-05-16 112138](https://github.com/anuragverma108/SwapReads/assets/121669832/fda5d9c9-e743-4438-a4ff-4af1c0c0a13d)
After change:
![Screenshot 2024-05-16 182436](https://github.com/anuragverma108/SwapReads/assets/121669832/bc857299-c130-45ef-85cd-3e1614da24b3)
