### PR TITLE
Improve newsletter title visibility in dark mode by changing font color from dark gray to white

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -48,6 +48,7 @@
   --seashell: hsl(20, 43%, 93%);
   --charcoal: hsl(203, 30%, 26%);
   --white: hsl(0, 0%, 100%);
+  --dark-gray: hsl(0, 0%, 22%);
 
   /**
    * typography
@@ -1206,7 +1207,6 @@ footer {
   justify-content: center;
   align-items: top;
   gap: 10px;
-
 }
 
 .input-newletter {
@@ -1218,7 +1218,7 @@ footer {
 }
 
 .social-icons h5 {
-  color: rgb(57, 57, 57);
+  color: var(--dark-gray);
   font-size: 2rem;
   font-weight: 500;
   text-align: center;
@@ -1849,6 +1849,7 @@ footer {
   --white: #1E1C1C;
   --black: #fff;
   --grey-white: #1E1C1C;
+  --dark-gray: #fff;
 
   /* shadow */
 


### PR DESCRIPTION
### Improve newsletter title visibility in dark mode by changing font color from dark gray to white

# Description

In this update, I've made the "Newsletter" text easier to read in dark mode by changing its color from dark gray to white. This adjustment improves the contrast between the text and the background, making it more readable for users.

Fixes:  #623

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
Before:
![image](https://github.com/anuragverma108/SwapReads/assets/123376306/59857a5a-f710-4fb3-87b2-277274881c31)
After:
![image](https://github.com/anuragverma108/SwapReads/assets/123376306/b47c9199-c496-4073-8a91-814294983d05)
