### PR TITLE
Correct typo error in Romance genre description

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@
           <h3 class="h3 card-title">Romance</h3>
 
           <p class="card-text">
-            a romance is understood to be "love stories", that are primarily focused on the relationship between the main characters of the story.The biggest defining characteristic of the romance genre is that a happy ending is always guaranteed, perhaps living "happily ever after".
+            "A romance is understood to be 'love stories,' which are primarily focused on the relationship between the main characters of the story. The biggest defining characteristic of the romance genre is that a happy ending is always guaranteed, perhaps living 'happily ever after.'" <!--The correction involves adding quotation marks around "love stories" and "happily ever after" for consistency and clarity.-->
           </p>
 
         </div>


### PR DESCRIPTION
# Description

In this pull request, I corrected a typographical error and improved clarity in the description of the "Romance" genre section in the index.html file.

Fixes:  #645 

<!---give the issue number you fixed----->

Changes Made:

Added quotation marks around "love stories" and "happily ever after" for consistency and clarity.
The corrected sentence now reads: "'A romance is understood to be 'love stories,' which are primarily focused on the relationship between the main characters of the story. The biggest defining characteristic of the romance genre is that a happy ending is always guaranteed, perhaps living 'happily ever after.'"

<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![Screenshot](https://i.imgur.com/MA92Yll.png)