### PR TITLE
Fix issue of typo romance genre

### DIFF
--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@
           <h3 class="h3 card-title">Romance</h3>
 
           <p class="card-text">
-            "A romance is understood to be 'love stories,' which are primarily focused on the relationship between the main characters of the story. The biggest defining characteristic of the romance genre is that a happy ending is always guaranteed, perhaps living 'happily ever after.'" <!--The correction involves adding quotation marks around "love stories" and "happily ever after" for consistency and clarity.-->
+            "A romance is understood to be 'love stories,' which are primarily focused on the relationship between the main characters of the story. The biggest defining characteristic of the romance genre is that a happy ending is always guaranteed, perhaps living 'happily ever after.'"
           </p>
 
         </div>

--- a/index.html
+++ b/index.html
@@ -416,7 +416,7 @@
           <h3 class="h3 card-title">Romance</h3>
 
           <p class="card-text">
-            a romance is understood to be "love stories", that are primarily focused on the relationship between the main characters of the story.The biggest defining characteristic of the romance genre is that a happy ending is always guaranteed, perhaps living "happily ever after".
+            "A romance is understood to be 'love stories,' which are primarily focused on the relationship between the main characters of the story. The biggest defining characteristic of the romance genre is that a happy ending is always guaranteed, perhaps living 'happily ever after.'" <!--The correction involves adding quotation marks around "love stories" and "happily ever after" for consistency and clarity.-->
           </p>
 
         </div>


### PR DESCRIPTION
# Description

In this pull request, I corrected the conflicting issues suggested by you, a typographical error and improved clarity in the description of the "Romance" genre section in the index.html file.

Fixes:  #(645)

<!---give the issue number you fixed----->

## Type of change

Added quotation marks around "love stories" and "happily ever after" for consistency and clarity.
The corrected sentence now reads: "'A romance is understood to be 'love stories,' which are primarily focused on the relationship between the main characters of the story. The biggest defining characteristic of the romance genre is that a happy ending is always guaranteed, perhaps living 'happily ever after.'"

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [ ] I have made this from my own 
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![Screenshot](https://i.imgur.com/MA92Yll.png)