### PR TITLE
fixed  the text and the login container is overlapping with each other (#589)

### DIFF
--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -20,7 +20,7 @@
 
 body {
   width: 100%;
-  height: 100vh;
+  height: 100%;
   font-family: var(--ff-philosopher);
   font-size: 4rem;
   /* background-color: #c9acc2; */


### PR DESCRIPTION
# Description

I fixed the text is overlapping with login page in light mode and the css is not showing to be correct so i replace height:100vh with height : 100% .

Fixes:  #589 



- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
before 
![Screenshot 2024-05-23 160015](https://github.com/anuragverma108/SwapReads/assets/118350936/b8632292-3f55-4c30-9a1d-6929a821f4b4)

After 
![Screenshot 2024-05-23 160030](https://github.com/anuragverma108/SwapReads/assets/118350936/f10488bd-2e5f-4cd3-a1f1-a7e633c74d17)


