### PR TITLE
 close option added in  booklist for swapping page

### DIFF
--- a/assets/css/addremove.css
+++ b/assets/css/addremove.css
@@ -23,9 +23,30 @@ body {
   margin: 0;
   padding: 0;
   display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
+  flex-direction: column;
+  justify-content: space-around;
+  position: relative;
+  
+  height: 100%;
+  width: 100%;
+}
+.navbar {
+  width: 100%;
+  background-color: #f5ebe6;
+ 
+}
+.navbar-header {
+  width: 100%;
+  font-family: var(--ff-poppins);
+  font-size: 4rem;
+  line-height: 1;
+ 
+  display: block;
+  text-decoration-color: #fff;
+}
+.navbar-header a {
+  color: rgb(247, 150, 150);
+  margin-left: 90%;
 }
 
 #container {

--- a/assets/html/addremovebook.html
+++ b/assets/html/addremovebook.html
@@ -11,6 +11,13 @@
 
 		</head>
 		<body>
+			<div class="navbar">
+				<div class="navbar-header">
+				  <a href="../../index.html">
+					<img class="close-icon" src="../images/close1.png" alt="Close" />
+				  </a>
+				</div>
+			</div>
 		<div id="container">
 		<h1>Your Booklist for Swapping</h1>
 		<div id="auth">


### PR DESCRIPTION
I have added close option in booklist for swapping page. This pull request makes the following changes :

Fixes:  #684 

## Type of change

- [x] New feature (non-breaking change which adds functionality)



# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![Screenshot 2024-05-24 045226](https://github.com/anuragverma108/SwapReads/assets/100590445/159464fc-e3c0-4ae4-b35d-eb3ae2b60128)
