### PR TITLE
aligned the back-to-top arrow and the chat icon

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2266,8 +2266,8 @@ footer {
 }
 #back-to-top-container {
   position: fixed;
-  bottom: 115px;
-  right: 35px; /* Changed left to right */
+  bottom: 135px;
+  right: 45px; /* Changed left to right */
   cursor: pointer;
   z-index: 1000;
 }

--- a/index.html
+++ b/index.html
@@ -121,12 +121,6 @@
             <a href="./assets/html/login.html" class="navbar-link">Login/Signup</a>
           </li>
 
-
-          <li class="navbar-item dropdown">
-            <a href="#" class="navbar-link">More <i class="ri-arrow-down-s-line"></i></a>
-            <div class="dropdown-menu">
-
-                    
           <li class="navbar-item dropdown" id="more-dropdown">
             <a href="#" class="navbar-link" id="more-link" onclick="toggleMoreDropdown(event)">More <i class="ri-arrow-down-s-line"></i></a>
             <div class="dropdown-menu" id="dropdown-menu">


### PR DESCRIPTION
# Description

I have changed the padding of back-to-top arrow to make it aligned with the chat icon.

# Fixes: #809 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have made this from my own
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![image](https://github.com/anuragverma108/SwapReads/assets/126975547/826c98e6-92c4-4ffa-9ecd-4eac3d95e065)

![image](https://github.com/anuragverma108/SwapReads/assets/126975547/c7ced2ff-16ae-46cb-a3e9-ac0c3a0d2d59)

