### PR TITLE
fixed the style for booktitle label in Book Exchange Hub form

### DIFF
--- a/index.html
+++ b/index.html
@@ -876,8 +876,7 @@
             <div class="form-fields">
               <div class="form-fields">
 
-                <label class="form-label" for="bookTitle">Book Title:</label>
-                <label class="form-label" for="bookTitle">Book Title:</label>
+                <label class="formform-label" for="bookTitle">Book Title:</label>
                 <input type="text" id="bookTitle" name="bookTitle" placeholder="Enter the title of your book" required
                   class="input-field">
 


### PR DESCRIPTION
Fixes #870  

# Description
This pull request fixes the issue #870 
The label for "Book title" in the Book Exchange Hub form was written twice and the style for the same was given wrong, I have fixed that issue.


# Type of PR

- [ X] Bug fix


# Screenshots / videos (if applicable)
before:
![Screenshot 2024-05-26 061014](https://github.com/anuragverma108/SwapReads/assets/142833275/783077d6-11db-4efe-98b2-18c0a9c2b0c0)


After: 
![image](https://github.com/anuragverma108/SwapReads/assets/142833275/72f5c58c-2b49-4ab2-bcf1-433bb4cfcf72)


# Checklist:

<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I have made this from my own
- [x] I have taken help from some online resources 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
