### PR TITLE
Price cards size is fixed

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -988,6 +988,10 @@ background-size: cover;
   transition: var(--transition-2);
   border-radius: var(--radius-5);
   box-shadow: var(--shadow-2);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100%;
 }
 
 .pricing-card:is(:hover, :focus-within),
@@ -1009,6 +1013,7 @@ background-size: cover;
 
 .pricing-card-list {
   margin-block: 20px 40px;
+  flex-grow: 1;
 }
 
 .pricing-card-list .card-item:not(:last-child) {
@@ -1021,6 +1026,8 @@ background-size: cover;
 
 .pricing-card .btn {
   margin-inline: auto;
+  align-self: center;
+  margin-top: auto;
 }
 
 /*-----------------------------------*\


### PR DESCRIPTION
# Related Issue

None

Fixes:  #834 

# Description

Previously the price cards in the pricing section were having an uneven size which was not looking good. Thus I made some changes in the style.css file so that all the 3 price cards have a regular and equal size.  After fixing this the cards are looking evenly sized and placed well for this project.

Issue no.: #834 

# Type of PR

- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Before the issue was fixed:
![swapreads](https://github.com/anuragverma108/SwapReads/assets/135226069/9529c19d-52a7-48eb-a36b-2574b3e79468)


After the issue was fixed:
![swapreads-4](https://github.com/anuragverma108/SwapReads/assets/135226069/d78bb3a9-6901-4b76-a7f5-340926fd8370)


# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own
- [ ] I have taken help from some online resourses 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
