### PR TITLE
alignment of language and pricing section in dark mode

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2714,4 +2714,24 @@ select {
   .book-image.dark-mode {
       border: 1px solid #ffffff;
   }
-  
+
+.cardo{
+  height: 28rem;
+}
+.pricing-card{
+  height :70rem
+}
+.card-title{
+  padding: 2px;
+}
+
+@media(max-width:300px){
+  .cardo{
+    height: fit-content;
+  }
+}
+@media(max-width:770px){
+  .pricing-card{
+    height: fit-content;
+  }
+}

--- a/assets/html/index.html
+++ b/assets/html/index.html
@@ -576,7 +576,7 @@
 
           <ul class="grid-list">
 
-            <li>
+            <li class = "gird-list-container">
 
               <a class="cardo" href="#">
                 <h3>09. &nbsp;Romantic Escapes</h3>
@@ -603,7 +603,7 @@
               </div> -->
             </li>
 
-            <li>
+            <li class = "gird-list-container">
 
               <a class="cardo" href="#">
                 <h3>02. &nbsp;Thrilling Adventures</h3>
@@ -628,7 +628,7 @@
               </div> -->
             </li>
 
-            <li>
+            <li class = "gird-list-container">
 
               <a class="cardo" href="#">
                 <h3>03. &nbsp;Mindful Living</h3>
@@ -655,7 +655,7 @@
               </div> -->
             </li>
 
-            <li>
+            <li class = "gird-list-container">
 
               <a class="cardo" href="#">
                 <h3>04. &nbsp;Mystical Fantasies</h3>
@@ -680,7 +680,7 @@
               </div> -->
             </li>
 
-            <li>
+            <li class = "gird-list-container">
 
               <a class="cardo" href="#">
                 <h3>05. &nbsp;Historical Chronicles</h3>
@@ -707,7 +707,7 @@
               </div> -->
             </li>
 
-            <li>
+            <li class = "gird-list-container">
 
               <a class="cardo" href="#">
                 <h3>06. &nbsp;Science Fiction Wonders</h3>
@@ -732,7 +732,7 @@
               </div> -->
             </li>
 
-            <li>
+            <li class = "gird-list-container">
 
               <a class="cardo" href="#">
                 <h3>07. &nbsp;Laugh Out Loud Comedy</h3>
@@ -759,7 +759,7 @@
               </div> -->
             </li>
 
-            <li>
+            <li class = "gird-list-container">
 
               <a class="cardo" href="#">
                 <h3>08. &nbsp;Intriguing Mysteries</h3>
@@ -784,7 +784,7 @@
               </div> -->
             </li>
 
-            <li>
+            <li class = "gird-list-container">
 
               <a class="cardo" href="#">
                 <h3>09. &nbsp;Inspiring Biographies</h3>


### PR DESCRIPTION
# Related Issue

None

Fixes:  #849 

# Description

The alignment of the literature book section and pricing section is off because the grids in these sections are not the same size. In light mode, the size of these grids is not visible because the grid color and background color are the same. However, in dark mode, they are evident. After the changes you can see the size of all grids are the same and responsive.

## Fixed Issue #849 

<!---give the issue number you fixed----->

# Type of PR

  [  ] Bug fix
  [✅] Enhancement
  [  ] Documentation update
  [  ] Other (specify): _______________

# Screenshots / videos (if applicable)
[I've attached the relevant screenshots that are before & after screenshots]

### BEFORE 
![Screenshot 2024-05-26 233659](https://github.com/anuragverma108/SwapReads/assets/134155725/87a915a2-26b8-4252-9ee5-422b4d83c673)
![Screenshot 2024-05-26 235743](https://github.com/anuragverma108/SwapReads/assets/134155725/fd6f564b-ea32-4d8f-a107-340e234391eb)


### AFTER
![Screenshot 2024-05-26 220350](https://github.com/anuragverma108/SwapReads/assets/134155725/0e9c6f2f-8546-4354-b505-c1221baa90f4)
![Screenshot 2024-05-26 220512](https://github.com/anuragverma108/SwapReads/assets/134155725/27c050b6-c4d8-4b1b-bbc9-35d30b0af0d7)


# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [✅] I have made this from my own
- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [✅] I have tested the changes thoroughly before submitting this pull request.
- [✅] I have provided relevant issue numbers, screenshots, and videos after making the changes.
