### PR TITLE
Added reset password connection

### DIFF
--- a/assets/html/forgot-pass.html
+++ b/assets/html/forgot-pass.html
@@ -4,7 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Forgot Password</title>
-<div class="navbar">
+  <link rel="stylesheet" type="text/css" href="../css/forgot-pass.css">
+  <script src="../js/forgotPassword.js" type="module" defer></script>
+</head>
+<body>
+  <div class="navbar">
     <nav>
       
     <a href="../../index.html">Home</a>
@@ -13,12 +17,6 @@
     <a href="index.html#contact">Contact</a>
   </nav>
 </div>
- 
-    <link rel="stylesheet" type="text/css" href="../css/forgot-pass.css">
-  
-</head>
-<body>
-
    <h1 class="bookworm">Hello There, Bookworms!</h1>
     <p class="bookworm2">Forgot your password?</p>
    <p class="bookworm3"> No worries! We'll send you a verification code on registered email.</P>

--- a/assets/js/fire.js
+++ b/assets/js/fire.js
@@ -1,23 +1,22 @@
-<script type="module">
-  // Import the functions you need from the SDKs you need
-  import { initializeApp } from "https://www.gstatic.com/firebasejs/10.8.1/firebase-app.js";
-  import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.8.1/firebase-analytics.js";
-  // TODO: Add SDKs for Firebase products that you want to use
-  // https://firebase.google.com/docs/web/setup#available-libraries
 
-  // Your web app's Firebase configuration
-  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
-  const firebaseConfig = {
-    apiKey: "AIzaSyCZjy9z9fuAGgbIQxjgsfvnbp_vEiJsLbk",
-    authDomain: "login-14d37.firebaseapp.com",
-    projectId: "login-14d37",
-    storageBucket: "login-14d37.appspot.com",
-    messagingSenderId: "172844646482",
-    appId: "1:172844646482:web:f55c1e6cd62774d898df8b",
-    measurementId: "G-SRVRX110W7"
-  };
+// Import the functions you need from the SDKs you need
+import { initializeApp } from "https://www.gstatic.com/firebasejs/10.8.1/firebase-app.js";
+import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.8.1/firebase-analytics.js";
+// TODO: Add SDKs for Firebase products that you want to use
+// https://firebase.google.com/docs/web/setup#available-libraries
 
-  // Initialize Firebase
-  const app = initializeApp(firebaseConfig);
-  const analytics = getAnalytics(app);
-</script>
+// Your web app's Firebase configuration
+// For Firebase JS SDK v7.20.0 and later, measurementId is optional
+const firebaseConfig = {
+  apiKey: "AIzaSyCZjy9z9fuAGgbIQxjgsfvnbp_vEiJsLbk",
+  authDomain: "login-14d37.firebaseapp.com",
+  projectId: "login-14d37",
+  storageBucket: "login-14d37.appspot.com",
+  messagingSenderId: "172844646482",
+  appId: "1:172844646482:web:f55c1e6cd62774d898df8b",
+  measurementId: "G-SRVRX110W7"
+};
+
+// Initialize Firebase
+const app = initializeApp(firebaseConfig);
+const analytics = getAnalytics(app);

--- a/assets/js/forgotPassword.js
+++ b/assets/js/forgotPassword.js
@@ -1,0 +1,36 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.8.1/firebase-app.js';
+import { getAnalytics } from 'https://www.gstatic.com/firebasejs/10.8.1/firebase-analytics.js';
+import {
+  getAuth,
+  sendPasswordResetEmail
+} from 'https://www.gstatic.com/firebasejs/10.8.1/firebase-auth.js';
+
+const firebaseConfig = {
+  apiKey: "AIzaSyAIDh842xGC_NZj6pMcB9THjNQ1DyUVnZU",
+  authDomain: "swapreads-c7d1d.firebaseapp.com",
+  projectId: "swapreads-c7d1d",
+  storageBucket: "swapreads-c7d1d.appspot.com",
+  messagingSenderId: "912206670085",
+  appId: "1:912206670085:web:9a6182b16ac2529510ef6c"
+};
+
+
+
+const app = initializeApp(firebaseConfig);
+getAnalytics(app)
+const auth = getAuth(app);
+
+const ResetForm = document.querySelector("#login-form")
+ResetForm.addEventListener("submit", (e)=>{
+    e.preventDefault()
+    const email = document.querySelector("#login_email").value
+    sendPasswordResetEmail(auth, email)
+    .then(() => {
+      alert("Password Reset email sent")
+    })
+    .catch((error) => {
+      const errorMessage = error.message;
+      alert("Email does not exists")
+  });
+});
+


### PR DESCRIPTION
# Related Issue

#276 

Fixes:  #276 

# Description

Since the reset password page has changed I thought it was a good time to tackle this issue. The reset password page is now connected with firebase for reset password functionality please change the firebase config or check if the following is turned on in firebase:

create a template for the reset password email:
![image](https://github.com/anuragverma108/SwapReads/assets/32983571/b66f3f1d-1248-4a8a-b35a-299b80b962c8)
![image](https://github.com/anuragverma108/SwapReads/assets/32983571/fc657bdf-67af-4226-bd6a-9c36d898ba9d)

disable email enumeration:
![image](https://github.com/anuragverma108/SwapReads/assets/32983571/626a5fc1-5689-4774-af36-b1a5a1b254ff)

or give me access to the firebase
# Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)

https://github.com/anuragverma108/SwapReads/assets/32983571/2967288f-bd49-49fc-ad4e-9fd896b4e8dd


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

