### PR TITLE
functional dark mode switch and non overlapping google translate and …

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -42,6 +42,8 @@
   cursor: pointer;
   padding: none;
   font-size: 15px;
+  display: flex;
+  align-items: center;
 }
 
 .form-label {
@@ -504,7 +506,7 @@ background-size: cover;
 .navbar {
   border: 1px solid #000;
   display: inline-block;
-  position: absolute;
+  position: relative;
   top: 100%;
   left: 0;
   width: 100%;
@@ -551,10 +553,9 @@ background-size: cover;
 }
 
 .navbar-item {
-  margin: 0 10px; /* Adjust the horizontal margin to increase spacing */
+  margin: 0 5px; /* Adjust the horizontal margin to increase spacing */
   padding: 0; /* Remove default padding */
 }
-
 
 .navbar-link {
   display: flex;
@@ -580,7 +581,7 @@ background-size: cover;
   padding: 10px;
   border-radius: 5px; */
   display: none;
-  position: absolute;
+  position: relative;
   background-color: #fff;
   box-shadow: 0 8px 16px rgba(0,0,0,0.2);
   z-index: 1;
@@ -681,7 +682,7 @@ background-size: cover;
 }
 
 .navbar-item {
-  margin: 0 10px;
+  margin: 10 10px;
   padding: 0;
 }
 
@@ -2243,6 +2244,9 @@ input[type="submit"]:hover {
 .dark-mode .navbar {
   /* background-color: #333; */
   color: #fff;
+  max-width: 1209px;
+  border-radius: 10px;
+  padding: 1rem;
 }
 
 .dark-mode .note {
@@ -2251,7 +2255,7 @@ input[type="submit"]:hover {
 
 .dark-mode .container {
   /* background-color: #333; */
-  padding: 25px;
+  padding: 1rem;
   color: #fff;
 }
 
@@ -2371,7 +2375,7 @@ footer {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-top: 30px;
+  margin-top: 40px;
   right:-4px;
   top: 35px;
 }

--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
           </li>
           
           <!-- Google Translate Element -->
-          <li class="navbar-item">
+          <!--<li class="navbar-item">
             <div id="google_element"></div>
         </li>
     </ul>
@@ -175,7 +175,7 @@ new google.translate.TranslateElement({
   pageLanguage: 'en'
 }, 'google_element');
 }
-</script>
+</script>>-->
             <div class="switch-container">
               <input type="checkbox" id="switch" class="switch-checkbox">
               <label for="switch" class="switch-label">
@@ -197,6 +197,19 @@ new google.translate.TranslateElement({
       </button>
 
     </div>
+    <script>
+      const switchInput = document.getElementById('switch');
+    
+      switchInput.addEventListener('change', function() {
+        if (this.checked) {
+          // Dark mode enabled
+          document.body.classList.add('dark-mode');
+        } else {
+          // Dark mode disabled
+          document.body.classList.remove('dark-mode');
+        }
+      });
+    </script>
   </header>
 
 
@@ -1516,6 +1529,17 @@ new google.translate.TranslateElement({
           <li class="foot-quick"><a href="#faqq" onclick="lenis.scrollTo('#faqq')">Faq</a></li>
         </ul>
       </div>
+      <div id="google_element"></div>
+<script src="https://translate.google.com/translate_a/element.js?cb=loadGoogleTranslate"></script>
+<script>
+  function loadGoogleTranslate() {
+    new google.translate.TranslateElement({
+      pageLanguage: 'en'
+    }, 'google_element');
+  }
+</script>
+
+
       <div class="social-icons">
         <!-- <h5>Newsletter</h5> -->
         <!-- <div class="input-newletter">


### PR DESCRIPTION
##Fixes #961 
Overlapping of the Dark Mode Switch and the google translate
 I resolved the problem of overlapping between the Google Translate widget and the dark mode switch by relocating the Google Translate widget to the footer of the webpage. 
I ensured that the dark mode switch functionality now works seamlessly, even for users who haven't logged in or signed up to the webpage. 
I made improvements to the layout by fixing the position of the dark mode switch and adjusting the positioning of the sun and moon images within the button.
I also fixed the size of the navigation bar in the dark mode as initially it was overlapping the text below it.
![Screenshot 2024-05-28 165418](https://github.com/anuragverma108/SwapReads/assets/142666229/e9872b03-4826-459f-99f4-d21de0dd5359)
![Screenshot 2024-05-28 165440](https://github.com/anuragverma108/SwapReads/assets/142666229/cf136944-55a1-4bec-a8eb-fd5915dbadac)
![Screenshot 2024-05-28 165517](https://github.com/anuragverma108/SwapReads/assets/142666229/cb82cfbc-539f-4517-87b4-d5d2a0a63930)
![Screenshot 2024-05-28 165535](https://github.com/anuragverma108/SwapReads/assets/142666229/3c83649e-eb14-48f2-93ac-b8a7d708bad6)

 These changes enhance the user experience and improve the overall usability of your website's homepage



