### PR TITLE
Bug Fixed: Overflowing Mobile Design

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1716,6 +1716,13 @@ input[type="submit"]:hover {
     padding-bottom: 1rem;
     padding-top: 1rem;
   }
+
+  html {
+    overflow-x: hidden;
+  }
+  .hero .hero-title{
+    font-size: 3rem;
+  }
 }
 
 @media (min-width: 575px) {


### PR DESCRIPTION
# Related Issue

None
Fixes:  #691 

# Description

Updated the overflowing of the Web Design on Mobile (Responsive View). Concurrently, fixed font size for the main heading in the hero section so that it doesn't cut when cutting down on the overflowing design. 

<!---give the issue number you fixed----->

# Type of PR

- [x] Bug fix

# Screenshots / videos (if applicable)
![image](https://github.com/anuragverma108/SwapReads/assets/69352438/e9caf419-4dfb-4cbd-9414-cbed19a58e82)
![image](https://github.com/anuragverma108/SwapReads/assets/69352438/fd821e45-e8cd-49d9-8bd1-2d40aeca9607)


# Checklist:


- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

