### PR TITLE
The numbering pattern of the cards "Explore Different Genres" was made uniform.

### DIFF
--- a/index.html
+++ b/index.html
@@ -713,7 +713,7 @@
             </li>
             <div class="chapter-card">
 
-              <p class="card-subtitle">9</p>
+              <p class="card-subtitle">09</p>
 
               <h3 class="h3 card-title">Historical Fiction</h3>
 


### PR DESCRIPTION

# Related Issue #1059 

Fixes:  #1059 

# Description

 In the "Explore Different Genres", the card of Historical Fiction is numbered "9" whereas the other cards are from "01" to "08" in regards to Issue #1059. I changed the "9" to "09".

# Type of PR

- [ ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [x] Other (specify): In the "Explore Different Genres", the card of Historical Fiction is numbered "9" whereas the other cards are from "01" to "08". I changed the "9" to "09".

# Screenshots / videos (if applicable)

Before:

![Screenshot 2024-05-30 173601](https://github.com/anuragverma108/SwapReads/assets/156996206/3075c552-4049-4592-9f1f-28c9d5508c0e)

After:

![Screenshot 2024-05-31 002509](https://github.com/anuragverma108/SwapReads/assets/156996206/0da7ac3e-3cef-439f-bf34-d2d5786b83ee)

# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

