### PR TITLE
Connect with the Reader button is in centre.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -405,7 +405,7 @@ body {
   margin-left: 0px;
   margin-top: 30px;
   text-align: center;
-  margin: 0 auto;
+  margin: auto;
 }
 
 .btn-primary:is(:hover, :focus) {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -405,7 +405,7 @@ body {
   margin-left: 0px;
   margin-top: 30px;
   text-align: center;
-  margin: auto;
+  margin : auto;
 }
 
 .btn-primary:is(:hover, :focus) {


### PR DESCRIPTION
# Related Issue

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

Fixes:  #(issue no.)
BUG:The "Connect with the Reader" button in Book exchange Hub section is not in the centre. #1073

# Description
Adjusted the margins.

<!---give the issue number you fixed----->

# Type of PR

- [x] Bug fix

# Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes. Make sure to attach before & after screenshots in your PR.]
Before:
<img width="1440" alt="Screenshot 2024-05-30 at 8 35 23 PM" src="https://github.com/anuragverma108/SwapReads/assets/119745655/fe225279-e170-4ed5-843d-6d5980072dac">

After:
<img width="1439" alt="Screenshot 2024-06-01 at 10 25 38 PM" src="https://github.com/anuragverma108/SwapReads/assets/119745655/ad0d2f1c-c8d4-4a80-aff3-84c3e3420f81">




# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

