### PR TITLE
Aligned the forgot password to center.

### DIFF
--- a/assets/html/login.html
+++ b/assets/html/login.html
@@ -169,7 +169,7 @@
           <button type="submit" name="Login" id="login">Submit</button>
           <div class="forget-password">
             Forgot Password?
-            <a href="forgot-pass.html" id="forgot_password_link">Reset Here</a>
+            <a href="forgot-pass.html" id="forgot_password_link" >Reset Here</a>
           </div>
           
           <div id="or">Or</div>
@@ -289,6 +289,9 @@
             color: #ff0001;
             /* Change to YouTube color on hover */
           }
+          .forget-password {
+            text-align: center;
+        }
         </style>
 
         <div class="icons">


### PR DESCRIPTION
# Related Issue
The forgot password was at the wrong alignment.I aligned it in the center,

Fixes:  #604
# Description
The forgot password aligned at its center.

I added a CSS style in the forgot-password section.
<!---give the issue number you fixed----->
#604

# Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Before :
![WhatsApp Image 2024-06-03 at 17 33 55_87ea011f](https://github.com/anuragverma108/SwapReads/assets/104766763/63350807-c21c-4343-af07-e78312b3dc79)


Now:
![image](https://github.com/anuragverma108/SwapReads/assets/104766763/ae75d949-6fb3-4a8b-8eba-5d8693381a58)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I thoroughly tested the changes before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

