### PR TITLE
Corrected navbar Padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
 
   <header class="header header-anim" data-header>
 
-    <div class="container mobile-container-styles">
+    <div class="container mobile-container-styles" style="padding-left: 0;">
 
       <nav class="navbar" data-navbar>
         <a href="#home" onclick="lenis.scrollTo('#home');" class="logo" style="display:flex;">


### PR DESCRIPTION
# Related Issue

Fixes:  #1329

# Description

Originally while toggling between Dark to Light mode and the other way, the navigation bar elements were changing a slight bit of position. I fixed it by adjusting the padding.

<!---give the issue number you fixed----->

# Type of PR

- [x] Bug fix

# Screenshots / videos (if applicable)
Before:
![image](https://github.com/anuragverma108/SwapReads/assets/145102345/339d3db3-1c66-4579-9644-d6b6b7f3d4bf)
![image](https://github.com/anuragverma108/SwapReads/assets/145102345/7943709b-783b-48ac-b318-143fdf508c8e)


After:
![image](https://github.com/anuragverma108/SwapReads/assets/145102345/c51460a4-5ea0-4ead-a542-d2e43aa1c65b)
![image](https://github.com/anuragverma108/SwapReads/assets/145102345/95b7af58-f059-4596-8711-f3668b47f987)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

