### PR TITLE
Fixed the visibility of text on free e book page.

### DIFF
--- a/assets/css/freeBooks.css
+++ b/assets/css/freeBooks.css
@@ -84,3 +84,9 @@
     background-color: var(--old-rose_30);
     box-shadow: 7px -7px var(--old-rose_30);
   }
+  .book_title{
+    color:white;
+  }
+  .section_text1{
+    color:white;
+  }

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -284,129 +284,129 @@ new google.translate.TranslateElement({
     <div class="container2">
         <div class="benefits-content">
             <h2 class="h2 section-title has-underline" data-sr-id="2" style="visibility: visible; opacity: 1; transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1); transition: opacity 2s cubic-bezier(0.5, 0, 0, 1) 0.1s, transform 2s cubic-bezier(0.5, 0, 0, 1) 0.1s;">Free E-Books</h2>
-            <p class="section-text1 " data-sr-id="42" style="visibility: visible; opacity: 1; transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1); transition: opacity 2s cubic-bezier(0.5, 0, 0, 1) 0.4s, transform 2s cubic-bezier(0.5, 0, 0, 1) 0.4s;">"Embark on Literary Journeys with Our Available Books!"</p>
+            <p class="section_text1 " data-sr-id="42" style="visibility: visible; opacity: 1; transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1); transition: opacity 2s cubic-bezier(0.5, 0, 0, 1) 0.4s, transform 2s cubic-bezier(0.5, 0, 0, 1) 0.4s;">"Embark on Literary Journeys with Our Available Books!"</p>
             <span class="span has-before"></span>
 
         </div>
         <div class="book-list">
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg" alt="Alice's Adventures in Wonderland" class="book-cover">
-                <h3 class="book-title">Alice's Adventures in Wonderland</h3>
+                <h3 class="book_title">Alice's Adventures in Wonderland</h3>
                 <a href="https://www.gutenberg.org/ebooks/11" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg" alt="Pride and Prejudice" class="book-cover">
-                <h3 class="book-title">Pride and Prejudice</h3>
+                <h3 class="book_title">Pride and Prejudice</h3>
                 <a href="https://www.gutenberg.org/ebooks/1342" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg" alt="Frankenstein" class="book-cover">
-                <h3 class="book-title">Frankenstein</h3>
+                <h3 class="book_title">Frankenstein</h3>
                 <a href="https://www.gutenberg.org/ebooks/84" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg" alt="Metamorphosis" class="book-cover">
-                <h3 class="book-title">Metamorphosis</h3>
+                <h3 class="book_title">Metamorphosis</h3>
                 <a href="https://www.gutenberg.org/ebooks/5200" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/1661/pg1661.cover.medium.jpg" alt="The Adventures of Sherlock Holmes" class="book-cover">
-                <h3 class="book-title">The Adventures of Sherlock Holmes</h3>
+                <h3 class="book_title">The Adventures of Sherlock Holmes</h3>
                 <a href="https://www.gutenberg.org/ebooks/1661" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg" alt="Alice's Adventures in Wonderland" class="book-cover">
-                <h3 class="book-title">Alice's Adventures in Wonderland</h3>
+                <h3 class="book_title">Alice's Adventures in Wonderland</h3>
                 <a href="https://www.gutenberg.org/ebooks/11" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg" alt="Pride and Prejudice" class="book-cover">
-                <h3 class="book-title">Pride and Prejudice</h3>
+                <h3 class="book_title">Pride and Prejudice</h3>
                 <a href="https://www.gutenberg.org/ebooks/1342" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg" alt="Frankenstein" class="book-cover">
-                <h3 class="book-title">Frankenstein</h3>
+                <h3 class="book_title">Frankenstein</h3>
                 <a href="https://www.gutenberg.org/ebooks/84" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg" alt="Metamorphosis" class="book-cover">
-                <h3 class="book-title">Metamorphosis</h3>
+                <h3 class="book_title">Metamorphosis</h3>
                 <a href="https://www.gutenberg.org/ebooks/5200" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/1661/pg1661.cover.medium.jpg" alt="The Adventures of Sherlock Holmes" class="book-cover">
-                <h3 class="book-title">The Adventures of Sherlock Holmes</h3>
+                <h3 class="book_title">The Adventures of Sherlock Holmes</h3>
                 <a href="https://www.gutenberg.org/ebooks/1661" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg" alt="Alice's Adventures in Wonderland" class="book-cover">
-                <h3 class="book-title">Alice's Adventures in Wonderland</h3>
+                <h3 class="book_title">Alice's Adventures in Wonderland</h3>
                 <a href="https://www.gutenberg.org/ebooks/11" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg" alt="Pride and Prejudice" class="book-cover">
-                <h3 class="book-title">Pride and Prejudice</h3>
+                <h3 class="book_title">Pride and Prejudice</h3>
                 <a href="https://www.gutenberg.org/ebooks/1342" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg" alt="Frankenstein" class="book-cover">
-                <h3 class="book-title">Frankenstein</h3>
+                <h3 class="book_title">Frankenstein</h3>
                 <a href="https://www.gutenberg.org/ebooks/84" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg" alt="Metamorphosis" class="book-cover">
-                <h3 class="book-title">Metamorphosis</h3>
+                <h3 class="book_title">Metamorphosis</h3>
                 <a href="https://www.gutenberg.org/ebooks/5200" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/1661/pg1661.cover.medium.jpg" alt="The Adventures of Sherlock Holmes" class="book-cover">
-                <h3 class="book-title">The Adventures of Sherlock Holmes</h3>
+                <h3 class="book_title">The Adventures of Sherlock Holmes</h3>
                 <a href="https://www.gutenberg.org/ebooks/1661" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg" alt="Alice's Adventures in Wonderland" class="book-cover">
-                <h3 class="book-title">Alice's Adventures in Wonderland</h3>
+                <h3 class="book_title">Alice's Adventures in Wonderland</h3>
                 <a href="https://www.gutenberg.org/ebooks/11" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg" alt="Pride and Prejudice" class="book-cover">
-                <h3 class="book-title">Pride and Prejudice</h3>
+                <h3 class="book_title">Pride and Prejudice</h3>
                 <a href="https://www.gutenberg.org/ebooks/1342" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg" alt="Frankenstein" class="book-cover">
-                <h3 class="book-title">Frankenstein</h3>
+                <h3 class="book_title">Frankenstein</h3>
                 <a href="https://www.gutenberg.org/ebooks/84" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg" alt="Metamorphosis" class="book-cover">
-                <h3 class="book-title">Metamorphosis</h3>
+                <h3 class="book_title">Metamorphosis</h3>
                 <a href="https://www.gutenberg.org/ebooks/5200" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/1661/pg1661.cover.medium.jpg" alt="The Adventures of Sherlock Holmes" class="book-cover">
-                <h3 class="book-title">The Adventures of Sherlock Holmes</h3>
+                <h3 class="book_title">The Adventures of Sherlock Holmes</h3>
                 <a href="https://www.gutenberg.org/ebooks/1661" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg" alt="Alice's Adventures in Wonderland" class="book-cover">
-                <h3 class="book-title">Alice's Adventures in Wonderland</h3>
+                <h3 class="book_title">Alice's Adventures in Wonderland</h3>
                 <a href="https://www.gutenberg.org/ebooks/11" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg" alt="Pride and Prejudice" class="book-cover">
-                <h3 class="book-title">Pride and Prejudice</h3>
+                <h3 class="book_title">Pride and Prejudice</h3>
                 <a href="https://www.gutenberg.org/ebooks/1342" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg" alt="Frankenstein" class="book-cover">
-                <h3 class="book-title">Frankenstein</h3>
+                <h3 class="book_title">Frankenstein</h3>
                 <a href="https://www.gutenberg.org/ebooks/84" class="btn btn-secondary">Download</a>
             </div>
             <div class="book-item">
                 <img src="https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg" alt="Metamorphosis" class="book-cover">
-                <h3 class="book-title">Metamorphosis</h3>
+                <h3 class="book_title">Metamorphosis</h3>
                 <a href="https://www.gutenberg.org/ebooks/5200" class="btn btn-secondary">Download</a>
             </div>
         </div>


### PR DESCRIPTION
# Related Issue

changed the text colour in dark mode which was not visible previously on the free e-books webpage.
Fixes:  #1304 

# Type of PR
- [ ] Documentation update

# Screenshots / videos (if applicable)

 Before:
<img width="1434" alt="Screenshot 2024-06-04 at 9 05 40 AM" src="https://github.com/anuragverma108/SwapReads/assets/144280247/ab2789de-b482-4c2f-a610-8bcffeacf5c7">

 After:
<img width="1434" alt="Screenshot 2024-06-04 at 9 04 45 AM" src="https://github.com/anuragverma108/SwapReads/assets/144280247/af52c2ce-da0c-4a29-96f5-c998e418eddb">


# Checklist:

- [ ] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers and screenshots after making the changes.

