### PR TITLE
Feat:hover color different from Current Theme #1425

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -789,6 +789,7 @@ body {
 
 .dropdown-menu-list {
   list-style: none;
+  
   margin: 0;
   padding: 0;
 }
@@ -2694,7 +2695,7 @@ body.dark-mode {
 
 body.dark-mode .navbar-link:hover,
 body.dark-mode .navbar-link.active {
-  color: hsl(357, 93%, 84%);
+  color:var(--old-rose);
 }
 
 body.dark-mode .navbar-link::after {


### PR DESCRIPTION
# Related Issue
Feat:hover color different from Current Theme #1425

Fixes:  #1425 

# Description
-fixed hover color
Before::
![Screenshot 2024-06-05 152734](https://github.com/anuragverma108/SwapReads/assets/101548649/780c7b8f-5f1d-4133-9bf4-d17a76961f0b)




After::
![Screenshot 2024-06-06 014158](https://github.com/anuragverma108/SwapReads/assets/101548649/521cf5d9-dc9c-43f0-84fe-87fa6da99eca)


<!---give the issue number you fixed----->

# Type of PR

- [ y] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [y ] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [ y] My code follows the style guidelines of this project.
- [y ] I have performed a self-review of my own code.
- [y ] I have commented my code, particularly in hard-to-understand areas.
- [y ] I have made corresponding changes to the documentation.
- [ y] My changes generate no new warnings.
- [y ] I have tested the changes thoroughly before submitting this pull request.
- [ y] I have provided relevant issue numbers and screenshots after making the changes.

