### PR TITLE
Add GitHub Icons to Footer Section of Login Page

### DIFF
--- a/assets/html/login.html
+++ b/assets/html/login.html
@@ -298,6 +298,10 @@
             color: #ff0001;
             /* Change to YouTube color on hover */
           }
+
+          .icons .icon:hover .fab.fa-github {
+            color: #333;
+          }
         </style>
 
         <div class="icons">
@@ -322,6 +326,12 @@
           <a href="https://www.youtube.com/@anuragbytes">
             <div class="icon">
               <i class="fab fa-youtube" style="cursor: pointer;"></i>
+            </div>
+          </a>
+
+          <a href="https://github.com/anuragverma108">
+            <div class="icon">
+              <i class="fab fa-github" style="cursor: pointer;"></i>
             </div>
           </a>
         </div>


### PR DESCRIPTION
Fixed issue: #1504 

This pull request adds GitHub icons to the footer section of the login page. The changes include:

- Adding GitHub icons to the footer for improved accessibility and user experience.
- Ensuring proper alignment and styling of the icons to match the overall design of the login page.

Fixes:  #1504 

Before making the changes:
![Screenshot 2024-06-06 203623](https://github.com/anuragverma108/SwapReads/assets/159511364/e9f8a41a-8a4f-40c0-9475-fa248c5b90a2)

After making the changes:
![Screenshot 2024-06-07 193829](https://github.com/anuragverma108/SwapReads/assets/159511364/a3454d03-22f5-47d6-99b4-9ff41d99d893)
