### PR TITLE
Added Social Icons to Footer of About Us Page

### DIFF
--- a/assets/html/about.html
+++ b/assets/html/about.html
@@ -13,6 +13,8 @@
 
   <link rel="stylesheet" href="assets/css/test-style.css">
 
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+
   <!-- <link rel="stylesheet" href="../css/login.css" /> -->
   <link rel="stylesheet" href="../css/style.css">
 
@@ -535,17 +537,17 @@
                 /* Scale the icon on hover */
               }
 
-              .icons .icon:hover .fab.fa-facebook-square {
+              .icons .icon:hover .fab.fa-facebook {
                 color: #3B5998;
                 /* Change to Facebook color on hover */
               }
 
-              .icons .icon:hover .fa-brands.fa-square-x-twitter {
+              .icons .icon:hover .fab.fa-twitter {
                 color: #090e11;
                 /* Change to Twitter color on hover */
               }
 
-              .icons .icon:hover .fab.fa-instagram-square {
+              .icons .icon:hover .fab.fa-instagram {
                 background: radial-gradient(circle at 30% 107%, #fdf497 0%, #fdf497 5%, #fd5949 45%, #d6249f 60%, #285AEB 90%);
                 background-clip: text;
                 border-radius: 20%;
@@ -554,34 +556,43 @@
                 /* Change to Instagram color on hover */
               }
 
-              .icons .icon:hover .fab.fa-youtube-square {
+              .icons .icon:hover .fab.fa-youtube {
                 color: #C31A1E;
                 /* Change to YouTube color on hover */
+              }
+
+              .icons .icon:hover .fab.fa-github {
+                color: #333;
               }
             </style>
 
             <div class="icons">
               <a href="#">
                 <div class="icon">
-                  <i class="fab fa-facebook-square" title="Facebook" style="cursor: pointer;"></i>
+                  <i class="fab fa-facebook" title="Facebook" style="cursor: pointer;"></i>
                 </div>
               </a>
 
               <a href="#">
                 <div class="icon">
-                  <i class="fa-brands fa-square-x-twitter" title="X" style="cursor: pointer;"></i>
+                  <i class="fab fa-twitter" title="X" style="cursor: pointer;"></i>
                 </div>
               </a>
 
               <a href="#">
                 <div class="icon">
-                  <i class="fab fa-instagram-square" title="Instagram" style="cursor: pointer;"></i>
+                  <i class="fab fa-instagram" title="Instagram" style="cursor: pointer;"></i>
                 </div>
               </a>
 
               <a href="https://www.youtube.com/@anuragbytes" title="YouTube">
                 <div class="icon">
-                  <i class="fab fa-youtube-square" style="cursor: pointer;"></i>
+                  <i class="fab fa-youtube" style="cursor: pointer;"></i>
+                </div>
+              </a>
+              <a href="https://github.com/anuragverma108">
+                <div class="icon">
+                  <i class="fab fa-github" style="cursor: pointer;"></i>
                 </div>
               </a>
             </div>


### PR DESCRIPTION
Fixed issue: #1508 

- Added social media icons (Facebook, Twitter, Instagram, YouTube, GitHub) to the footer section of the About Us page.
- Ensured proper alignment and styling of the icons to match the overall design of the page.

This update enhances the About Us page by providing easy access to our social media profiles, improving user engagement and connectivity.


Fixes:  #1508 

Before making the changes:
![Screenshot 2024-06-06 221155](https://github.com/anuragverma108/SwapReads/assets/159511364/bb42c903-cb68-45b6-947b-30aa0b88c685)

After making the changes:

![Screenshot 2024-06-07 200550](https://github.com/anuragverma108/SwapReads/assets/159511364/600016f7-e060-4819-916a-5ad7da7f2a97)
