### PR TITLE
Corrected flip-card's color problem

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2705,14 +2705,7 @@ body.dark-mode .navbar-link::after {
   box-shadow: 0 0 10px #fcb0b480;
 }
 
-body.dark-mode .flip-card-back{
-  background-color: black !important;
-  color: white !important;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-}
+
 
 body.dark-mode .navbar-link:hover::after {
   box-shadow: 0 0 20px hsl(357, 93%, 84%, 0.7);

--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
       padding: 10px;
     }
 
-    /* Do an horizontal flip when you move the mouse over the flip box container */
+    /* Do a horizontal flip when you move the mouse over the flip box container */
     .flip-card:hover .flip-card-inner {
       transform: rotateY(180deg);
     }
@@ -146,16 +146,20 @@
       backface-visibility: hidden;
     }
 
-    /* Style the front side (fallback if image is missing) */
-    .flip-card-front {
+    /* Style the front side (fallback if image is missing) in light mode */
+    .light-mode .flip-card-front {
       background-color: white;
       color: black;
+    }
+    
+    /* Style the front side (fallback if image is missing) in dark mode*/
+    .dark-mode .flip-card-front {
+      background-color: black;
+      color: white;
     }
 
     /* Style the back side */
     .flip-card-back {
-      background-color: white;
-      color: black;
       transform: rotateY(180deg);
     }
 
@@ -168,11 +172,31 @@
 
     .light-mode .readmore-anim:hover {
       color: red;
-      letter-spacing: 1px;
+      letter-spacing: 100px;
       transition: ease-in-out;
     }
 
+    /*Flipped card when in light mode*/
 
+    body.light-mode .flip-card-back{
+      background-color: white !important;
+      color: black !important;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+    }
+    
+    /*Flipped card whenn in dark mode*/
+
+    body.dark-mode .flip-card-back{
+      background-color: black !important;
+      color: white !important;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+    }
 
     /* Dark Mode Styles */
     .dark-mode .readmore-anim {
@@ -190,6 +214,9 @@
       letter-spacing: 1px;
       transition: ease-in-out;
     }
+
+
+
 
     /* pankaj bind */
     #cookie-consent {
@@ -1343,6 +1370,7 @@
   <swiper-container class="mySwiper" pagination="true" pagination-clickable="true" navigation="true" space-between="40"
     loop="true" >
     <swiper-slide>
+
       <div class="flip-card">
         <div class="flip-card-inner">
           <div class="flip-card-front fronts dark-mode">


### PR DESCRIPTION
# Related Issue

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

Fixes:  #1573

# Description

Earlier when hovering over reviews in light mode, the reviews flipped to look like:
![image](https://github.com/anuragverma108/SwapReads/assets/145102345/0517a2b5-75ac-4d4a-bdf0-af96e2aef269)

I changed them to look like:
![image](https://github.com/anuragverma108/SwapReads/assets/145102345/2756b1ac-35e7-46d7-8565-59e8ee833f59)


<!---give the issue number you fixed----->

# Type of PR

- [x] Bug fix

# Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes. Make sure to attach before & after screenshots in your PR.]

# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

