### PR TITLE
Reset preloader loading time 

### DIFF
--- a/assets/js/preloader.js
+++ b/assets/js/preloader.js
@@ -9,6 +9,6 @@ document.addEventListener("DOMContentLoaded", function() {
             preloader.classList.add('hidden');
             mainContent.classList.remove('hidden');
             mainContent.classList.add('visible');
-        }, 3000); // 2000 milliseconds = 2 seconds delay
+        }, 500); // 2000 milliseconds = 2 seconds delay
     });
 });


### PR DESCRIPTION
# Related Issue

The timing for preloader was given of 3000 milli seconds ,I have reset it to 500 milliseconds as it was too much taking loading


Fixes:  #1511 

# Description

The timing for preloader was given of 3000 milli seconds ,I have reset it to 500 milliseconds as it was too much taking loading


<!---give the issue number you fixed----->

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)


https://github.com/anuragverma108/SwapReads/assets/142833275/cec74307-7642-4589-a8a0-baffe52721e8


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

