### PR TITLE
Overlapping icon on login and sign-up page fixed

### DIFF
--- a/assets/css/login.css
+++ b/assets/css/login.css
@@ -221,6 +221,23 @@ label {
   transition: 0.5s ease-in-out;
 }
 
+input[type="password"]::-webkit-textfield-decoration-container {
+  display: none;
+}
+
+input[type="password"]::-moz-textfield-decoration-container {
+  display: none;
+}
+
+input[type="password"]::-ms-clear {
+  display: none;
+}
+
+input[type="password"]::-ms-reveal {
+  display: none;
+}
+
+
 .input {
   width: 100%;
   height: 40px;


### PR DESCRIPTION
Fixes:  #1471 

# Description
Overlap of icons while we enter password fixed.

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)

Before : 
![image](https://github.com/anuragverma108/SwapReads/assets/116306749/5a06d1da-8072-460a-97d0-a396af655843)

After : 
![image](https://github.com/anuragverma108/SwapReads/assets/116306749/02ebfceb-b2b4-4dd8-be7b-b1d36f718fe2)

![image](https://github.com/anuragverma108/SwapReads/assets/116306749/d785b8ac-113b-4e65-97b8-1e7d58dc0c13)


# Checklist:


- [x] I have made this change from my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

