### PR TITLE
Fix: remove double email input area, completes #1606

### DIFF
--- a/index.html
+++ b/index.html
@@ -1841,26 +1841,8 @@
 
           <label for="email">Subscribe to our Newsletter</label>
           <div class="row-flex">
-            <input type="email" name="email" id="email" placeholder="  email address" style="background-color: white; margin-left: 20px; height: 40px;">
-
-
-              <button type="submit" class="subscribe-btn">Subscribe</button>
-
-
-
-            <!--email write-->
-            
-            <!-- <input type="news" value="" name="email" placeholder="email address">
-            <input type="submit" value="Subscribe" name="subscribe" class="subscribe-btn"> 
-            <input type="news" value="" name="email" placeholder="email address" id="newsletter-email" style="width:270px;">
-            <button type="submit" class="subscribe-btn">subscribe</button> -->
-
             <input type="news" value="" name="email" placeholder="email address" id="newsletter-email">
             <input type="submit" value="Subscribe" name="subscribe" class="subscribe-btn">
-
-
-
-
           </div>
       </form>
       <div id="confirmationMessage" style="display: none;">Thank you for subscribing!</div>


### PR DESCRIPTION
# Related Issue

Fixes:  #1606

# Description

Removed extra input area for email in the footer area of the home page. Completes issue number #1606

# Type of PR

- [x] Bug fix

# Screenshots / videos (if applicable)

Before:
![image](https://github.com/anuragverma108/SwapReads/assets/74809468/c05c9e80-6b42-4aaa-a5e1-08a7937d0e77)

After:
![image](https://github.com/anuragverma108/SwapReads/assets/74809468/18287e2f-3549-471b-9714-fde9d4298c50)

# Checklist:
- [x] I have made this change from my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.