### PR TITLE
Added about us in the nav bar in the about page

### DIFF
--- a/assets/html/about.html
+++ b/assets/html/about.html
@@ -184,7 +184,10 @@
             <li class="navbar-item">
               <a href="../../index.html" class="navbar-link" data-nav-link><i class="ri-home-fill"></i> Home</a>
             </li>
-
+            <li class="navbar-item">
+              <a href="./assets/html/about.html"  class="navbar-link" data-nav-link><i
+                  class="ri-home-fill"></i> About Us </a>
+            </li>
             <li class="navbar-item">
               <a href="../../index.html#benefits" class="navbar-link" data-nav-link><i class="ri-bar-chart-fill"></i>
                 Benefits</a>


### PR DESCRIPTION
# Related Issue

Previously there is no about us option in the nav bar in the about us page now i have added it in the nav bar

Fixes:  #1665 

# Description


Previously there is no about us option in the nav bar in the about us page now i have added it in the nav bar

<!---give the issue number you fixed----->

# Type of PR

- [x ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)

Before 
![image](https://github.com/anuragverma108/SwapReads/assets/143107589/eb4ee7d2-0df5-46fc-9e80-38de40026111)

after 
![image](https://github.com/anuragverma108/SwapReads/assets/143107589/74cfcc62-066c-4223-ba40-c532872a96ca)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x ] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x ] I have performed a self-review of my own code.
- [x ] I have commented my code, particularly in hard-to-understand areas.
- [x ] I have made corresponding changes to the documentation.
- [x ] My changes generate no new warnings.
- [x ] I have tested the changes thoroughly before submitting this pull request.
- [x ] I have provided relevant issue numbers and screenshots after making the changes.

