### PR TITLE
Duplicate GitHub Icon fixed--#1661

### DIFF
--- a/assets/html/about.html
+++ b/assets/html/about.html
@@ -671,7 +671,7 @@
       </div>
 
 
-              .icons .icon:hover .fab.fa-facebook {
+              <!-- .icons .icon:hover .fab.fa-facebook {
                 color: #3B5998;
                 /* Change to Facebook color on hover */
               }
@@ -736,7 +736,7 @@
                 <script>document.write(new Date().getFullYear())</script> All Rights Reserved. Made with ❤ by Guardian
                 Hackers.
               </p>
-            </div>
+            </div> -->
 
 
 

--- a/index.html
+++ b/index.html
@@ -1869,11 +1869,7 @@
               <i class="fab fa-instagram" title="Instagram"style="cursor: pointer;"></i>
             </div>
           </a>
-          <a href="https://github.com/anuragverma108/SwapReads" title="Github">
-            <div class="icon">
-              <i class="fab fa-github" style="cursor: pointer;"></i>
-            </div>
-          </a>
+          
 
           <a href="https://www.youtube.com/@anuragbytes" title="YouTube">
             <div class="icon">


### PR DESCRIPTION
Fixes:  #1661

# Description
There were dublicates github icons in the footer section of home page.
#1661

# Type of PR
Bug fix

# Screenshots / videos (if applicable)
Before:
![Screenshot 2024-06-10 003058](https://github.com/anuragverma108/SwapReads/assets/168854094/fcae9a20-5d85-4b6e-a501-575e90a65117)

After:
![image](https://github.com/anuragverma108/SwapReads/assets/168854094/ad060d28-ea76-495e-84e2-15dc30f44ff1)

# Checklist:

- [ X] I have made this change from my own.
- [X ] My code follows the style guidelines of this project.
- [ X] I have performed a self-review of my own code.
- [ X] My changes generate no new warnings.
- [X ] I have tested the changes thoroughly before submitting this pull request.
- [ X] I have provided relevant issue numbers and screenshots after making the changes.

