### PR TITLE
BUG:Two Github logo in footer.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1838,11 +1838,11 @@
               <i class="fab fa-youtube" style="cursor: pointer;"></i>
             </div>
           </a>
-          <a href="https://github.com/anuragverma108" title="GitHub">
+          <!-- <a href="https://github.com/anuragverma108" title="GitHub">
             <div class="icon">
                 <i class="fab fa-github" style="cursor: pointer;"></i>
             </div>
-          </a>
+          </a> -->
         </div>
        
 

--- a/index.html
+++ b/index.html
@@ -1838,11 +1838,6 @@
               <i class="fab fa-youtube" style="cursor: pointer;"></i>
             </div>
           </a>
-          <!-- <a href="https://github.com/anuragverma108" title="GitHub">
-            <div class="icon">
-                <i class="fab fa-github" style="cursor: pointer;"></i>
-            </div>
-          </a> -->
         </div>
        
 


### PR DESCRIPTION
# Related Issue

This fixes the bug of two github icons at the bottom footer, which is not looking good

Fixes:  #1691

# Description

One of the two github icons related to the repository of the website is present now.

#1691

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
![Screenshot (216)](https://github.com/anuragverma108/SwapReads/assets/108150261/0a6afb00-5ce5-4cd9-8260-66bb00b21435)

# Checklist:

- [x] I have made this change from my own.

