### PR TITLE
HTML JS fixed for learn more in cookie modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
       align-items: center;
       width: 300px;
       height: fit-content;
-      z-index: 100;
+      z-index: 100000;
       border-radius: 10px;
       margin-bottom: 5px;
       margin: 20px;
@@ -286,10 +286,12 @@
       height: 40px;
       color: white;
       background-color: #A30F17;
+      border-radius: 5px;
     }
     .reject-cookies {
       margin-top: 10px;
       padding-top: 5px;
+      border-radius: 5px;
       height: 40px;
       width: 280px;
       color: white;
@@ -299,14 +301,7 @@
       color: white;
       background-color: #A30F17;
 }
-.reject-cookies {
-  margin-top: 10px;
-  padding-top: 5px;
-  height: 40px;
-  width: 280px;
-  color: white;
-  background-color: #A30F17;
-}
+
 
 .accept-cookies:hover, .reject-cookies:hover {
   transform: scale(0.9);
@@ -367,18 +362,25 @@
   </div>
 
   <div id="cookie-consent">
-
-   
-    <p style="color: black;">We use cookies to improve your experience. By using our website, you consent to all cookies in accordance with
-      our Cookie Policy. <a href="#">Learn More</a></p>
+    <p style="color: black;">
+        We use cookies to improve your experience. By using our website, you consent to all cookies in accordance with our Cookie Policy. 
+        <a href="#" id="learn-more-link">Learn More</a>
+    </p>
+    <div id="learn-more-content" style="display: none; color: black;">
+        <p>Cookies are small text files that can be used by websites to make a user's experience more efficient. The law states that we can store cookies on your device if they are strictly necessary for the operation of this site. For all other types of cookies we need your permission.</p>
+        <p>This site uses different types of cookies. Some cookies are placed by third party services that appear on our pages.</p>
+    </div>
     <button class="accept-cookies">Accept</button>
     <button class="reject-cookies">Reject</button>
 </div>
+
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     const cookieConsent = document.getElementById('cookie-consent');
     const acceptButton = document.querySelector('.accept-cookies');
     const rejectButton = document.querySelector('.reject-cookies');
+    const learnMoreLink = document.getElementById('learn-more-link');
+    const learnMoreContent = document.getElementById('learn-more-content');
 
     // Check if the user has already made a choice
     if (localStorage.getItem('cookieConsent')) {
@@ -399,8 +401,16 @@
     rejectButton.addEventListener('click', function() {
       handleConsent('rejected');
     });
+
+    // Add event listener to "Learn More" link
+    learnMoreLink.addEventListener('click', function(event) {
+      event.preventDefault();
+      learnMoreContent.style.display = 'block';
+      learnMoreLink.style.display = 'none';
+    });
   });
 </script>
+
   <div id="preloader">
     <div class="loader">
       <div class="book-wrapper">


### PR DESCRIPTION
# Related Issue

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

Fixes:  #1712 

# Description

[Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.]
The learn more option stopped working, maybe it was deleted due to intermedeate pulls. I fixed the modal JS and added content. Now when learn more is clicked, full details of cookie opens.

<!---give the issue number you fixed----->

# Type of PR

- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes. Make sure to attach before & after screenshots in your PR.]

https://github.com/anuragverma108/SwapReads/assets/146661411/94bfea2e-418b-4399-87a5-edb062f44a80


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

