### PR TITLE
fixed colour of linkedin icon on hover 

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -326,4 +326,8 @@ box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2); /* Add shadow for better visibility */
   }
   .icons .icon:hover .fab.fa-github {
             color: #333;
-        }
+  }
+  
+            .icons .icon:hover .fab.fa-linkedin   {
+              color:#0077B5;
+            }   


### PR DESCRIPTION
# Related Issue

Fixes:  #1745 

# Description

I have fixed the issue and now on hover the colour of linkedin changes to its icon colour .

<!---give the issue number you fixed----->

# Type of PR

- [X] Bug fix

# Screenshots / videos (if applicable)

https://github.com/anuragverma108/SwapReads/assets/159682348/74ddbae6-f28a-448c-8c51-9810a9eb5ff6



# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

