### PR TITLE
Resolved Quick Links Navigation Issue on Free E-books Page Footer

### DIFF
--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -630,12 +630,12 @@ new google.translate.TranslateElement({
           <div id="quicklinks">
             <div>
             <ul>
-              <li class="foot-quick"><a href="#home" onclick="lenis.scrollTo('#home')">Home</a></li>
-              <li class="foot-quick"><a href="#benefits" onclick="lenis.scrollTo('#benefits')">Benefits</a></li>
-              <li class="foot-quick"><a href="#chapters" onclick="lenis.scrollTo('#chapters')">Literary Realms</a></li>
-              <li class="foot-quick"><a href="#pricing" onclick="lenis.scrollTo('#pricing')">Pricing</a></li>
+              <li class="foot-quick"><a href="../../index.html#home" onclick="lenis.scrollTo('#home')">Home</a></li>
+              <li class="foot-quick"><a href="../../index.html#benefits" onclick="lenis.scrollTo('#benefits')">Benefits</a></li>
+              <li class="foot-quick"><a href="../../index.html#chapters" onclick="lenis.scrollTo('#chapters')">Literary Realms</a></li>
+              <li class="foot-quick"><a href="../../index.html#pricing" onclick="lenis.scrollTo('#pricing')">Pricing</a></li>
               <li class="foot-quick">
-                <a href="./assets/html/book_recommend.html" onclick="lenis.scrollTo('#contact')">Recommended Book</a></li>
+                <a href="./book_recommend.html" onclick="lenis.scrollTo('#contact')">Recommended Book</a></li>
             </ul>
           </div>
           <!-- <div>
@@ -666,14 +666,14 @@ new google.translate.TranslateElement({
                 onclick="lenis.scrollTo('#contact')">E-Book</a></li>
             <li class="foot-quick"><a href="../../index.html#contact" onclick="lenis.scrollTo('#contact')">Contact Us</a></li> -->
 
-            <li class="foot-quick"><a href="./assets/html/booklistswap.html" onclick="lenis.scrollTo('#contact')">Swap
+            <li class="foot-quick"><a href="./booklistswap.html" onclick="lenis.scrollTo('#contact')">Swap
                 BookList</a></li>
-            <li class="foot-quick"><a href="./assets/html/freeBooks.html"
+            <li class="foot-quick"><a href="./freeBooks.html"
                 onclick="lenis.scrollTo('#contact')">E-Book</a></li>
-            <li class="foot-quick"><a href="./assets/html/about.html" onclick="lenis.scrollTo('#contact')">About</a>
+            <li class="foot-quick"><a href="./about.html" onclick="lenis.scrollTo('#contact')">About</a>
             </li>
-            <li class="foot-quick"><a href="#contact" onclick="lenis.scrollTo('#contact')">Contact Us</a></li>
-            <li class="foot-quick"><a href="#faqq" onclick="lenis.scrollTo('#faqq')">FAQ</a></li>
+            <li class="foot-quick"><a href="../../index.html#contact" onclick="lenis.scrollTo('#contact')">Contact Us</a></li>
+            <li class="foot-quick"><a href="../../index.html#faqq" onclick="lenis.scrollTo('#faqq')">FAQ</a></li>
 
           </ul>
         </div>


### PR DESCRIPTION
Fixed issue: #1584 

The quick links in the footer section of the free e-books page were not functioning as expected, causing navigation issues. Clicking on any of the quick links did not redirect users to the intended sections or pages. This issue has been resolved to ensure smooth and seamless navigation for users. All quick links are now fully operational and correctly redirect to their respective destinations.

Fixes:  #1584 

- [x] Bug fix
- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

After making the changes:

https://github.com/anuragverma108/SwapReads/assets/159511364/67dec4ad-5f74-4d4c-8840-96e416618476
