### PR TITLE
Fixed repetition of books in free e book page and added new books also fixed extra "rights reserved line in footer "

### DIFF
--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -412,9 +412,9 @@ new google.translate.TranslateElement({
                 <button onclick="addToReadLater(8)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg" alt="Metamorphosis" class="book-cover">
-                <h3 class="book_title">Metamorphosis</h3>
-                <a href="https://www.gutenberg.org/ebooks/5200" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/18857/pg18857.cover.medium.jpg" alt="A Journey to the Centre of the Earth" class="book-cover">
+                <h3 class="book_title">A Journey to the Centre of the Earth</h3>
+                <a href="https://www.gutenberg.org/ebooks/18857" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(9)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -394,9 +394,9 @@ new google.translate.TranslateElement({
                 <button onclick="addToReadLater(5)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg" alt="Alice's Adventures in Wonderland" class="book-cover">
-                <h3 class="book_title">Alice's Adventures in Wonderland</h3>
-                <a href="https://www.gutenberg.org/ebooks/11" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/25973/pg25973.cover.medium.jpg" alt="Birds of the Rockies by Leander" class="book-cover">
+                <h3 class="book_title">Birds of the Rockies by Leander</h3>
+                <a href="https://www.gutenberg.org/ebooks/25973" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(6)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -400,9 +400,9 @@ new google.translate.TranslateElement({
                 <button onclick="addToReadLater(6)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg" alt="Pride and Prejudice" class="book-cover">
-                <h3 class="book_title">Pride and Prejudice</h3>
-                <a href="https://www.gutenberg.org/ebooks/1342" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/31516/pg31516.cover.medium.jpg" alt="The Eyes Have It" class="book-cover">
+                <h3 class="book_title">The Eyes Have It</h3>
+                <a href="https://www.gutenberg.org/ebooks/31516" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(7)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -454,9 +454,9 @@ new google.translate.TranslateElement({
                 <button onclick="addToReadLater(15)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg" alt="Alice's Adventures in Wonderland" class="book-cover">
-                <h3 class="book_title">Alice's Adventures in Wonderland</h3>
-                <a href="https://www.gutenberg.org/ebooks/11" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/41562/pg41562.cover.medium.jpg" alt="The Hanging Stranger" class="book-cover">
+                <h3 class="book_title">The Hanging Stranger</h3>
+                <a href="https://www.gutenberg.org/ebooks/41562" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(16)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -460,53 +460,59 @@ new google.translate.TranslateElement({
                 <button onclick="addToReadLater(16)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg" alt="Pride and Prejudice" class="book-cover">
-                <h3 class="book_title">Pride and Prejudice</h3>
-                <a href="https://www.gutenberg.org/ebooks/1342" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/50133/pg50133.cover.medium.jpg" alt="The Dunwich Horror" class="book-cover">
+                <h3 class="book_title">The Dunwich Horror</h3>
+                <a href="https://www.gutenberg.org/ebooks/50133" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(17)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg" alt="Frankenstein" class="book-cover">
-                <h3 class="book_title">Frankenstein</h3>
-                <a href="https://www.gutenberg.org/ebooks/84" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/68/pg68.cover.medium.jpg" alt="The warlord of Mars" class="book-cover">
+                <h3 class="book_title">The warlord of Mars</h3>
+                <a href="https://www.gutenberg.org/ebooks/68" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(18)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg" alt="Metamorphosis" class="book-cover">
-                <h3 class="book_title">Metamorphosis</h3>
-                <a href="https://www.gutenberg.org/ebooks/5200" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/72/pg72.cover.medium.jpg" alt="Thuvia, Maid of Mars by Edgar Rice Burroughs" class="book-cover">
+                <h3 class="book_title">Thuvia, Maid of Mars</h3>
+                <a href="https://www.gutenberg.org/ebooks/72" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(19)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/1661/pg1661.cover.medium.jpg" alt="The Adventures of Sherlock Holmes" class="book-cover">
-                <h3 class="book_title">The Adventures of Sherlock Holmes</h3>
-                <a href="https://www.gutenberg.org/ebooks/1661" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/51461/pg51461.cover.medium.jpg" alt="A Pail of Air" class="book-cover">
+                <h3 class="book_title">A Pail of Air</h3>
+                <a href="https://www.gutenberg.org/ebooks/51461" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(20)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg" alt="Alice's Adventures in Wonderland" class="book-cover">
-                <h3 class="book_title">Alice's Adventures in Wonderland</h3>
-                <a href="https://www.gutenberg.org/ebooks/11" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/18668/pg18668.cover.medium.jpg" alt="In Search of the Unknown" class="book-cover">
+                <h3 class="book_title">In Search of the Unknown</h3>
+                <a href="https://www.gutenberg.org/ebooks/18668" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(21)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg" alt="Pride and Prejudice" class="book-cover">
-                <h3 class="book_title">Pride and Prejudice</h3>
-                <a href="https://www.gutenberg.org/ebooks/1342" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/31979/pg31979.cover.medium.jpg" alt="The Tunnel Under the World" class="book-cover">
+                <h3 class="book_title">The Tunnel Under the World</h3>
+                <a href="https://www.gutenberg.org/ebooks/31979" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(22)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg" alt="Frankenstein" class="book-cover">
-                <h3 class="book_title">Frankenstein</h3>
-                <a href="https://www.gutenberg.org/ebooks/84" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/42259/pg42259.cover.medium.jpg" alt="The People of the Black Circle" class="book-cover">
+                <h3 class="book_title">The People of the Black Circle</h3>
+                <a href="https://www.gutenberg.org/ebooks/42259" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(23)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg" alt="Metamorphosis" class="book-cover">
-                <h3 class="book_title">Metamorphosis</h3>
-                <a href="https://www.gutenberg.org/ebooks/5200" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/32825/pg32825.cover.medium.jpg" alt="The Goddess of Atvatabar" class="book-cover">
+                <h3 class="book_title">The Goddess of Atvatabar</h3>
+                <a href="https://www.gutenberg.org/ebooks/32825" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(24)" class="read_later_button">Add to Read Later</button>
             </div>
+            <div class="book-item">
+              <img src="https://www.gutenberg.org/cache/epub/20727/pg20727.cover.medium.jpg" alt="The Cosmic Computer" class="book-cover">
+              <h3 class="book_title">The Cosmic Computer</h3>
+              <a href="https://www.gutenberg.org/ebooks/20727" class="btn btn-secondary">Download</a>
+              <button onclick="addToReadLater(24)" class="read_later_button">Add to Read Later</button>
+          </div>
         </div>
     </div>
 </section>
@@ -989,12 +995,12 @@ new google.translate.TranslateElement({
         </div>
       </div>
       <!-- adding privacy policy and copyright popup-->
-      <div style="text-align: center; align-items: center;">
+      <!-- <div style="text-align: center; align-items: center;">
         <p style="text-align: center">
           &copy;
           <script>document.write(new Date().getFullYear())</script> All Rights Reserved. Made with ❤ by Guardian Hackers.
         </p>
-      </div>
+      </div> -->
 
 
 

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -424,15 +424,15 @@ new google.translate.TranslateElement({
                 <button onclick="addToReadLater(10)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/11/pg11.cover.medium.jpg" alt="Alice's Adventures in Wonderland" class="book-cover">
-                <h3 class="book_title">Alice's Adventures in Wonderland</h3>
-                <a href="https://www.gutenberg.org/ebooks/11" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/1268/pg1268.cover.medium.jpg" alt="The Mysterious Island" class="book-cover">
+                <h3 class="book_title">The Mysterious Island</h3>
+                <a href="https://www.gutenberg.org/ebooks/1268" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(11)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/1342/pg1342.cover.medium.jpg" alt="Pride and Prejudice" class="book-cover">
-                <h3 class="book_title">Pride and Prejudice</h3>
-                <a href="https://www.gutenberg.org/ebooks/1342" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/139/pg139.cover.medium.jpg" alt="The Lost World" class="book-cover">
+                <h3 class="book_title">The Lost World</h3>
+                <a href="https://www.gutenberg.org/ebooks/139" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(12)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -406,9 +406,9 @@ new google.translate.TranslateElement({
                 <button onclick="addToReadLater(7)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg" alt="Frankenstein" class="book-cover">
-                <h3 class="book_title">Frankenstein</h3>
-                <a href="https://www.gutenberg.org/ebooks/84" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/159/pg159.cover.medium.jpg" alt="The island of Doctor Moreau" class="book-cover">
+                <h3 class="book_title">The island of Doctor Moreau</h3>
+                <a href="https://www.gutenberg.org/ebooks/159" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(8)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -436,9 +436,9 @@ new google.translate.TranslateElement({
                 <button onclick="addToReadLater(12)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/84/pg84.cover.medium.jpg" alt="Frankenstein" class="book-cover">
-                <h3 class="book_title">Frankenstein</h3>
-                <a href="https://www.gutenberg.org/ebooks/84" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/2488/pg2488.cover.medium.jpg" alt="Twenty Thousand Leagues Under the Seas: An Underwater Tour of the World" class="book-cover">
+                <h3 class="book_title">Twenty Thousand Leagues Under the Seas</h3>
+                <a href="https://www.gutenberg.org/ebooks/2488" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(13)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -442,9 +442,9 @@ new google.translate.TranslateElement({
                 <button onclick="addToReadLater(13)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/5200/pg5200.cover.medium.jpg" alt="Metamorphosis" class="book-cover">
-                <h3 class="book_title">Metamorphosis</h3>
-                <a href="https://www.gutenberg.org/ebooks/5200" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/42243/pg42243.cover.medium.jpg" alt="The Hour of the Dragon" class="book-cover">
+                <h3 class="book_title">The Hour of the Dragon</h3>
+                <a href="https://www.gutenberg.org/ebooks/42243" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(14)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -418,9 +418,9 @@ new google.translate.TranslateElement({
                 <button onclick="addToReadLater(9)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/1661/pg1661.cover.medium.jpg" alt="The Adventures of Sherlock Holmes" class="book-cover">
-                <h3 class="book_title">The Adventures of Sherlock Holmes</h3>
-                <a href="https://www.gutenberg.org/ebooks/1661" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/62/pg62.cover.medium.jpg" alt="A Princess of Mars" class="book-cover">
+                <h3 class="book_title">A Princess of Mars</h3>
+                <a href="https://www.gutenberg.org/ebooks/62" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(10)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -448,9 +448,9 @@ new google.translate.TranslateElement({
                 <button onclick="addToReadLater(14)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">
-                <img src="https://www.gutenberg.org/cache/epub/1661/pg1661.cover.medium.jpg" alt="The Adventures of Sherlock Holmes" class="book-cover">
-                <h3 class="book_title">The Adventures of Sherlock Holmes</h3>
-                <a href="https://www.gutenberg.org/ebooks/1661" class="btn btn-secondary">Download</a>
+                <img src="https://www.gutenberg.org/cache/epub/83/pg83.cover.medium.jpg" alt="From the Earth to the Moon" class="book-cover">
+                <h3 class="book_title">From the Earth to the Moon</h3>
+                <a href="https://www.gutenberg.org/ebooks/83" class="btn btn-secondary">Download</a>
                 <button onclick="addToReadLater(15)" class="read_later_button">Add to Read Later</button>
             </div>
             <div class="book-item">


### PR DESCRIPTION
Fixes:  #1880 

# Description
Added new books in place of repeting books hence providing more variety of books in free e books web page and removed extra rights reserved line in footer section.


# Type of PR

- [X] Bug fix


# Screenshots / videos (if applicable)
**BEFORE**

![Screenshot 2024-06-15 033440](https://github.com/anuragverma108/SwapReads/assets/159682348/81ba206d-eacc-4b3e-9e08-0d450f97e993)

![image](https://github.com/anuragverma108/SwapReads/assets/159682348/2fe6bd9b-c716-4614-9e19-a42a93b46bec)


**AFTER**

https://github.com/anuragverma108/SwapReads/assets/159682348/380b68e6-d012-4d33-b924-8fec38417595





**FOOTER**
![image](https://github.com/anuragverma108/SwapReads/assets/159682348/51b2dd50-46b5-4da8-9302-12ff9140f0f0)


# Checklist:



- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

