### PR TITLE
Fixed testimonials text visibility in light mode

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1429,7 +1429,7 @@ textarea.input-field {
   border-color: var(--old-rose);
 }
 
-.contact-form .btn {
+#contact-form .btn {
   margin-inline: auto;
 }
 
@@ -1620,6 +1620,12 @@ textarea.input-field {
   font-size: 2rem;
   border-radius: 5px;
   display: none;
+}
+
+/* for testimonials text visibility in light-mode */
+body.light-mode .flip-card-back {
+  background-color: white !important;
+  color: black !important;
 }
 
 /* Media Query for Responsive Design */

--- a/index.html
+++ b/index.html
@@ -1275,7 +1275,7 @@ document.addEventListener('DOMContentLoaded', function() {
               </div>
             </div>
           </div>
-          <div class="flip-card-back backs"  >
+          <div class="flip-card-back backs">
             SwapReads has completely transformed my reading experience! Not only have I discovered new books I never
             would have picked up otherwise, but I've also connected with fellow book lovers who share my passion. It's
             like having a personalized library with endless possibilities. Highly recommend!


### PR DESCRIPTION
# Related Issue

BUG: Testimonial text is not visible in light mode

Fixes:  #1825 

# Description
This fixes the text visibility issue of the Testimonials section in light mode, including detailed documenting in the code with a comment.

Before: 
![Screenshot (234)](https://github.com/anuragverma108/SwapReads/assets/108150261/9c168780-b8ee-4589-b872-9950bfb57d67)

After:
![Screenshot (243)](https://github.com/anuragverma108/SwapReads/assets/108150261/60a3a418-5b57-4982-a6e6-df0019ea2e16)

Also this fixes the issue of positioning of the "Send Now" button in contact form in dark mode. (This was fixed earlier, but was reverted and fixed now) 

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Checklist:

- [x] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

