### PR TITLE
add close button to consent

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3,6 +3,17 @@ swiper-container {
   width: 100%;
   height: 75%;
 }
+/* cookies close button */
+.close-btn {
+  position: absolute;
+  top: 5px;
+  right: 10px;
+  background: none;
+  border: none;
+  color: #050505;
+  font-size: 24px;
+  cursor: pointer;
+}
 
 /* Theme Change Button Style */
 .switch-container {

--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@
   </div>
   <script src="script.js"></script>
 <script>
+  
   document.addEventListener('DOMContentLoaded', function() {
   const cookieConsent = document.getElementById('cookie-consent');
   const acceptButton = document.querySelector('.accept-cookies');

--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
   </div>
   
   <div id="cookie-consent">
+    <button class="close-btn" id="closeBtn">&times;</button>
     <p>
         We use cookies to improve your experience. By using our website, you consent to all cookies in accordance with our Cookie Policy. 
         <a href="#" id="learn-more-link">Learn More</a>
@@ -104,8 +105,9 @@
     <button class="accept-cookies">Accept</button>
     <button class="reject-cookies">Reject</button>
   </div>
+  <script src="script.js"></script>
 <script>
-document.addEventListener('DOMContentLoaded', function() {
+  document.addEventListener('DOMContentLoaded', function() {
   const cookieConsent = document.getElementById('cookie-consent');
   const acceptButton = document.querySelector('.accept-cookies');
   const rejectButton = document.querySelector('.reject-cookies');

--- a/index.html
+++ b/index.html
@@ -97,17 +97,20 @@
     <p>
         We use cookies to improve your experience. By using our website, you consent to all cookies in accordance with our Cookie Policy. 
         <a href="#" id="learn-more-link">Learn More</a>
+        
     </p>
     <div id="learn-more-content" style="display: none;">
         <p>Cookies are small text files that can be used by websites to make a user's experience more efficient. The law states that we can store cookies on your device if they are strictly necessary for the operation of this site. For all other types of cookies we need your permission.</p>
         <p>This site uses different types of cookies. Some cookies are placed by third party services that appear on our pages.</p>
     </div>
+    <a href="#" id="show-less-link" style="display: none;">Show Less</a>
     <button class="accept-cookies">Accept</button>
     <button class="reject-cookies">Reject</button>
   </div>
+
   <script src="script.js"></script>
 <script>
-  
+
   document.addEventListener('DOMContentLoaded', function() {
   const cookieConsent = document.getElementById('cookie-consent');
   const acceptButton = document.querySelector('.accept-cookies');

--- a/script.js
+++ b/script.js
@@ -1,5 +1,54 @@
+// document.addEventListener("DOMContentLoaded", function() {
+//     var learnMoreLink = document.getElementById('learn-more-link');
+//     var learnMoreContent = document.getElementById('learn-more-content');
+//     var acceptButton = document.querySelector('.accept-cookies');
+//     var rejectButton = document.querySelector('.reject-cookies');
+//     var cookieConsent = document.getElementById('cookie-consent');
+//     var closeButton = document.getElementById('closeBtn');
+
+//     // Toggle learn more content visibility
+//     learnMoreLink.addEventListener('click', function(event) {
+//         event.preventDefault();
+//         if (learnMoreContent.style.display === 'none') {
+//             learnMoreContent.style.display = 'block';
+//         } else {
+//             learnMoreContent.style.display = 'none';
+//         }
+//     });
+
+//     // Accept cookies action
+//     acceptButton.addEventListener('click', function() {
+//         // Add your logic for accepting cookies here (e.g., setting cookies)
+//         hideCookieConsent();
+//     });
+
+//     // Reject cookies action
+//     rejectButton.addEventListener('click', function() {
+//         // Add your logic for rejecting cookies here (e.g., disabling non-essential cookies)
+//         hideCookieConsent();
+//     });
+
+//     // Close button action
+//     closeButton.addEventListener('click', function() {
+//         hideCookieConsent();
+//     });
+
+//     // Function to hide the cookie consent banner
+//     function hideCookieConsent() {
+//         cookieConsent.style.display = 'none';
+//         sessionStorage.setItem('cookieBannerDismissed', 'true');
+//     }
+
+//     // Check if the cookie consent banner was dismissed previously
+//     if (sessionStorage.getItem('cookieBannerDismissed')) {
+//         cookieConsent.style.display = 'none';
+//     }
+// });
+
+
 document.addEventListener("DOMContentLoaded", function() {
     var learnMoreLink = document.getElementById('learn-more-link');
+    var showLessLink = document.getElementById('show-less-link');
     var learnMoreContent = document.getElementById('learn-more-content');
     var acceptButton = document.querySelector('.accept-cookies');
     var rejectButton = document.querySelector('.reject-cookies');
@@ -9,11 +58,17 @@ document.addEventListener("DOMContentLoaded", function() {
     // Toggle learn more content visibility
     learnMoreLink.addEventListener('click', function(event) {
         event.preventDefault();
-        if (learnMoreContent.style.display === 'none') {
-            learnMoreContent.style.display = 'block';
-        } else {
-            learnMoreContent.style.display = 'none';
-        }
+        learnMoreContent.style.display = 'block';
+        learnMoreLink.style.display = 'none';
+        showLessLink.style.display = 'inline'; // Show "Show Less" link
+    });
+
+    // Toggle less content visibility
+    showLessLink.addEventListener('click', function(event) {
+        event.preventDefault();
+        learnMoreContent.style.display = 'none';
+        learnMoreLink.style.display = 'inline'; // Show "Learn More" link
+        showLessLink.style.display = 'none'; // Hide "Show Less" link
     });
 
     // Accept cookies action

--- a/script.js
+++ b/script.js
@@ -1,0 +1,46 @@
+document.addEventListener("DOMContentLoaded", function() {
+    var learnMoreLink = document.getElementById('learn-more-link');
+    var learnMoreContent = document.getElementById('learn-more-content');
+    var acceptButton = document.querySelector('.accept-cookies');
+    var rejectButton = document.querySelector('.reject-cookies');
+    var cookieConsent = document.getElementById('cookie-consent');
+    var closeButton = document.getElementById('closeBtn');
+
+    // Toggle learn more content visibility
+    learnMoreLink.addEventListener('click', function(event) {
+        event.preventDefault();
+        if (learnMoreContent.style.display === 'none') {
+            learnMoreContent.style.display = 'block';
+        } else {
+            learnMoreContent.style.display = 'none';
+        }
+    });
+
+    // Accept cookies action
+    acceptButton.addEventListener('click', function() {
+        // Add your logic for accepting cookies here (e.g., setting cookies)
+        hideCookieConsent();
+    });
+
+    // Reject cookies action
+    rejectButton.addEventListener('click', function() {
+        // Add your logic for rejecting cookies here (e.g., disabling non-essential cookies)
+        hideCookieConsent();
+    });
+
+    // Close button action
+    closeButton.addEventListener('click', function() {
+        hideCookieConsent();
+    });
+
+    // Function to hide the cookie consent banner
+    function hideCookieConsent() {
+        cookieConsent.style.display = 'none';
+        sessionStorage.setItem('cookieBannerDismissed', 'true');
+    }
+
+    // Check if the cookie consent banner was dismissed previously
+    if (sessionStorage.getItem('cookieBannerDismissed')) {
+        cookieConsent.style.display = 'none';
+    }
+});


### PR DESCRIPTION
Fixes:  #1726 

# Description

Added a close button to the cookie consent banner for easier dismissal by users.

**Before**

![cookieee](https://github.com/anuragverma108/SwapReads/assets/121204667/6ff1fa0f-95cd-4161-8e01-cb64ebee4829)

**After**

https://github.com/anuragverma108/SwapReads/assets/121204667/c2f3d450-c692-4513-ae7c-f3c671464901





# Type of PR

- [ ] Bug fix
- [ x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________



# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [ x] I have made this change from my own.
- [ x] I have taken help from some online resources.
- [x ] My code follows the style guidelines of this project.
- [x ] I have performed a self-review of my own code.
- [ x] I have commented my code, particularly in hard-to-understand areas.
- [ x] I have made corresponding changes to the documentation.
- [x ] My changes generate no new warnings.
- [ x] I have tested the changes thoroughly before submitting this pull request.
- [x ] I have provided relevant issue numbers and screenshots after making the changes.

