### PR TITLE
Social media links added to the footer in read later webpage.

### DIFF
--- a/assets/css/read_later.css
+++ b/assets/css/read_later.css
@@ -2612,3 +2612,6 @@ footer {
           background-color: rgb(0, 0, 0);
           background-color: rgba(0, 0, 0, 0.4);
       }
+      #newsletter-email{
+        background-color: white;
+      }

--- a/assets/html/read_later.html
+++ b/assets/html/read_later.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="../modals(privacy policy).css">
 
   <link rel="stylesheet" href="./assets/css/MenuClick.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 </head>
 <body>
     <header class="header header-anim" data-header>
@@ -220,7 +221,7 @@
             <label for="newsletter-email" class="newsletter-form">Subscribe to our Newsletter</label>
             <div class="row-flex">
                 <!-- Email input -->
-                <input type="email" id="newsletter-email" name="email" placeholder="E mail address" pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\.com$" 
+                <input type="email" id="newsletter-email" name="email" placeholder="E MAIL ADDRESS" pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\.com$" 
                 title="Please enter a valid email address that ends with '.com'" required>
                 <input type="submit" value="Subscribe" name="subscribe" class="subscribe-btn">
             </div>


### PR DESCRIPTION
# Related Issue
Social media links added to the footer in read later webpage.

Fixes:  #1959 

# Description
Social media links added to the footer in read later webpage. and also the background colour of the email placeholder changed as per the footer of the other webpages.

<!---give the issue number you fixed----->

# Type of PR
- [ ] Documentation update

# Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes. Make sure to attach before & after screenshots in your PR.]
Before:

<img width="603" alt="Screenshot 2024-06-18 at 9 37 06 PM" src="https://github.com/anuragverma108/SwapReads/assets/144280247/e0288947-a465-4639-a47b-68ddbc1ce799">

After:

<img width="603" alt="Screenshot 2024-06-18 at 9 29 59 PM" src="https://github.com/anuragverma108/SwapReads/assets/144280247/5bbf45e3-c9a7-43d7-9731-7cf27edc1c37">


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

