### PR TITLE
[feat]:adding-github-icon in about us section

### DIFF
--- a/assets/html/about.html
+++ b/assets/html/about.html
@@ -852,6 +852,12 @@ function showConfirmationMessage() {
             <i class="fab fa-youtube" style="cursor: pointer;"></i>
           </div>
         </a>
+
+        <a href="">
+          <div class="icon">
+            <i class="fab fa-github" title="Github"></i>
+          </div>
+        </a>
        
       </div>
      


### PR DESCRIPTION
# Related Issue


Fixes:  #2198
# Description
github icon is missing in about section page

<!---give the issue number you fixed----->

# Type of PR


- [*] Feature enhancement


# Screenshots / videos (if applicable)
![image](https://github.com/anuragverma108/SwapReads/assets/155576040/5992092e-24d1-4c67-8c92-b9061ddd01cf)
video-

https://github.com/anuragverma108/SwapReads/assets/155576040/2b13dbac-393f-4878-8536-d66b1f240b23


