### PR TITLE
Feat/add GitHub ink to team members card and fixes dark mode of read later in privacy notice and copyright policy .

### DIFF
--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -63,6 +63,10 @@ body{
     color: rgb(191, 110, 87);
 
 }
-.gitlin{
-    text-decoration: none;
+.modal-content {
+    background-color: var(--white);
+    margin: 15% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
 }

--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -63,10 +63,3 @@ body{
     color: rgb(191, 110, 87);
 
 }
-.modal-content {
-    background-color: var(--white);
-    margin: 15% auto;
-    padding: 20px;
-    border: 1px solid #888;
-    width: 80%;
-}

--- a/assets/css/about.css
+++ b/assets/css/about.css
@@ -63,3 +63,6 @@ body{
     color: rgb(191, 110, 87);
 
 }
+.gitlin{
+    text-decoration: none;
+}

--- a/assets/css/read_later.css
+++ b/assets/css/read_later.css
@@ -2606,5 +2606,11 @@ footer {
           background-color: rgb(0, 0, 0);
           background-color: rgba(0, 0, 0, 0.4);
       }
-
+      .modal-content {
+        background-color: var(--white);
+        margin: 15% auto;
+        padding: 20px;
+        border: 1px solid #888;
+        width:80% ;
+    }
      

--- a/assets/html/about.html
+++ b/assets/html/about.html
@@ -571,34 +571,38 @@
       <h2>Meet Our Team</h2>
       <div class="team-cards">
         <!-- Team member cards will go here -->
+         <a id="gitlin"  href="https://github.com/anuragverma108" style="text-decoration: none;">
         <div class="team-member" data-tilt>
           <img src="../images/pic1.jpeg" alt="Team Member 1">
           <div class="member-info">
             <h3>Anurag Verma</h3>
             <p>Project Admin</p>
           </div>
-        </div>
+        </div></a>
+       <a id="gitlin" href="https://github.com/huamanraj"style="text-decoration: none;">
         <div class="team-member">
           <img src="../images/pic2.jpeg" alt="Team Member 2">
           <div class="member-info">
             <h3>Aman Raj</h3>
             <p>Mentor</p>
           </div>
-        </div>
+        </div></a>
+        <a class="gitlin" href="https://github.com/RitiChandak"style="text-decoration: none;">
         <div class="team-member">
           <img src="../images/pic3.jpeg" alt="Team Member 3">
           <div class="member-info">
             <h3>Riti Chandak</h3>
             <p>Mentor</p>
           </div>
-        </div>
+        </div></a>
+        <a class="gitlin" href="https://github.com/RishabhDhawad"style="text-decoration: none;">
         <div class="team-member">
           <img src="../images/pic4.jpeg" alt="Team Member 4">
           <div class="member-info">
             <h3>Rishabh Dhawad</h3>
             <p>Mentor</p>
           </div>
-        </div>
+        </div></a>
         <!-- Add more team member cards as needed -->
       </div>
     </section>


### PR DESCRIPTION

Fixes:  #2211 

# Description

- added github link of team members in their card as it is not present in website .

- fixed copyright policy and privacy notice not visible in dark mode IN READ LATER PAGE 

<!---give the issue number you fixed----->

# Type of PR

- [X] Bug fix
- [X] Feature enhancement


# Screenshots / videos (if applicable)

BEFORE : 


https://github.com/anuragverma108/SwapReads/assets/159682348/9787b8c4-7473-4809-b7a8-87ae102c42bc



AFTER : 

- https://github.com/anuragverma108/SwapReads/assets/159682348/ac4e080f-3f87-48f2-bed5-c66799a1c497


- https://github.com/anuragverma108/SwapReads/assets/159682348/e914e6e6-2366-42d9-88f6-48380e4a0403



# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

