### PR TITLE
[BUG]:literary realms not visible

### DIFF
--- a/assets/css/litrary_realms.css
+++ b/assets/css/litrary_realms.css
@@ -18,6 +18,7 @@ body {
 }
 .section {
     padding: 0;
+    
 }
 
 .section-subtitle {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -391,6 +391,7 @@ body {
 
 .section {
   padding-block: var(--section-padding);
+  margin-top: 70px;
 }
 
 .section-subtitle {


### PR DESCRIPTION


Fixes:  #2270

# Description
text is not visible due to lack of margin in literary realms page


# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
![image](https://github.com/anuragverma108/SwapReads/assets/155576040/12603240-32ec-43e2-b2ad-05b8a336de6c)

