### PR TITLE
[Bug]:literary realms not visible

### DIFF
--- a/assets/css/litrary_realms.css
+++ b/assets/css/litrary_realms.css
@@ -18,7 +18,6 @@ body {
 }
 .section {
     padding: 0;
-    
 }
 
 .section-subtitle {

--- a/assets/css/litrary_realms.css
+++ b/assets/css/litrary_realms.css
@@ -18,6 +18,7 @@ body {
 }
 .section {
     padding: 0;
+    
 }
 
 .section-subtitle {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -391,6 +391,7 @@ body {
 
 .section {
   padding-block: var(--section-padding);
+  margin-top: 70px;
 }
 
 .section-subtitle {


### PR DESCRIPTION

Fixes:  #2270

# Description

text is not visible due to lack of margin in literary realms page

<!---give the issue number you fixed----->

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
![image](https://github.com/anuragverma108/SwapReads/assets/155576040/a2ed7374-dcd5-4a24-bb5c-0b7f211efab2)


