### PR TITLE
Changed the color of Back-To-Top Button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -847,8 +847,7 @@ body {
   padding: 0;
 }
 
-.dropdown-menu-item {
-}
+
 
 .dropdown-menu-item a {
   text-decoration: none;
@@ -2979,7 +2978,7 @@ footer {
 }
 
 #back-to-top:hover {
-  fill: black;
+  fill: #3c3c3c;
 }
 
 /* Switch Container */


### PR DESCRIPTION
# Related Issue

None

Fixes:  #2465 

# Description
I have changed the color of Back to top button as it was not going apt with the website's theme. I've given the same hover effect as given to the Chatbot Button.
PS- I've also deleted an empty selector in the same file which gave a warning.

Issue:- #2465 

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
This is how it looked before,
![image](https://github.com/user-attachments/assets/5c0e0fbb-bbcb-46c8-aac6-0cb7627e977d)

This is how it looks now,
![image](https://github.com/user-attachments/assets/4af72ea1-8872-4ff2-a7c5-a130e962d252)

You can also check it's hovering effect.

# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

Thank You PA @anuragverma108, for assigning me this issue under GSSOC'24! Please add Level 1 Label to this PR.
Please let me know if you want me to make some other changes in the same.
