### PR TITLE
Fixed Visible boundary in dark mode

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1369,6 +1369,14 @@ body.dark-mode .chapter-card:hover {
   background-color: var(--seashell);
   padding: 20px;
   border-radius: var(--radius-5);
+  border: 2px solid hsl(20, 43%, 93%);
+ 
+}
+
+@media (prefers-color-scheme: dark) {
+  .contact-card {
+    border: 2px solid var(--sonic-silver);
+  }
 }
 
 .contact-card .input-field {

--- a/index.html
+++ b/index.html
@@ -2320,7 +2320,7 @@
             <span class="span has-before"></span>
           </h2>
           <div class="wrapper">
-            <div class="contact-card">
+            <div class="contact-card ">
 
               <form action="http://localhost:3000/contact" method="POST" id="contact-form">
                 <div class="contact_head_wrapper">


### PR DESCRIPTION
# Related Issue
Fixes: #2635 

# Description
This PR adds a white border to the contact card in dark mode only. It enhances the visual separation of the contact form from the background in dark mode, improving overall readability and user experience.

The changes include:
- Ensuring the border is not visible in light mode
- Adjusting the background color for better contrast in dark mode

# Type of PR
- [x] Feature enhancement

# Screenshots
Before -
![Screenshot from 2024-07-26 14-24-35](https://github.com/user-attachments/assets/e647fdd1-b3e6-426e-99d9-feb785b81b1e)
After - 
![Screenshot from 2024-07-26 14-40-37](https://github.com/user-attachments/assets/654f0885-91a8-453a-9198-1d8254136f04)


# Checklist:
- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.