### PR TITLE
FIXED BUG: Dark Mode Title Color Changes on Book Recommendation Page

### DIFF
--- a/assets/css/BookRecommend.css
+++ b/assets/css/BookRecommend.css
@@ -589,7 +589,7 @@ body.dark-mode .h3 {
 }
 
 .dark-mode .section-subtitle {
-  color: rgb(255, 212, 212);
+  color: rgb(255, 208, 208);
 }
 
 @media only screen and (max-width:700px) {

--- a/assets/css/BookRecommend.css
+++ b/assets/css/BookRecommend.css
@@ -14,11 +14,13 @@
   justify-content: center;
   align-items: center;
 }
+
 #heading {
   /* margin-top: 50px; */
   justify-content: center;
   align-items: center;
 }
+
 .container00 {
   max-width: 900px;
   max-height: 800px;
@@ -65,17 +67,22 @@
 
 .author input[type="text"]:focus {
   border: 2px solid #c27a7e;
-  outline: none; /* Remove default outline */
-  box-shadow: 0 0 5px rgba(194, 122, 126, 0.5); /* Add a subtle shadow effect on focus */
+  outline: none;
+  /* Remove default outline */
+  box-shadow: 0 0 5px rgba(194, 122, 126, 0.5);
+  /* Add a subtle shadow effect on focus */
 }
 
 .author input[type="text"]:hover {
   border: 2px solid #c27a7e;
-  background-color: #f8e0e0; /* Add a subtle background color change on hover */
-  box-shadow: 0 0 5px rgba(194, 122, 126, 0.5); /* Add a subtle shadow effect on hover */
+  background-color: #f8e0e0;
+  /* Add a subtle background color change on hover */
+  box-shadow: 0 0 5px rgba(194, 122, 126, 0.5);
+  /* Add a subtle shadow effect on hover */
   transition: all 200ms ease;
 }
-.preference-bar > * {
+
+.preference-bar>* {
   margin: 0 10px;
   /* Add spacing between items */
 }
@@ -104,10 +111,12 @@ select {
 }
 
 #upb {
-  display: inline-block; /* Ensures the underline fits the text width */
+  display: inline-block;
+  /* Ensures the underline fits the text width */
   position: relative;
   cursor: pointer;
-  font-size: 24px; /* Adjust font size as needed */
+  font-size: 24px;
+  /* Adjust font size as needed */
 }
 
 #upb::after {
@@ -116,7 +125,8 @@ select {
   width: 0;
   height: 2px;
   display: block;
-  bottom: -2px; /* Position the underline just below the text */
+  bottom: -2px;
+  /* Position the underline just below the text */
   left: 0;
   background: #ff9b9b;
   transition: width 0.4s ease, left 0.4s ease;
@@ -170,14 +180,6 @@ select {
   /* Adding a shadow for better focus indication */
 }
 
-.dark-mode .preference-bar label,
-.dark-mode .preference-bar select:hover,
-.dark-mode .container00 h2,
-.dark-mode #recommendationTitle {
-  color: white;
-  /* Color for dark mode */
-}
-
 .book {
   display: flex;
   margin-bottom: 20px;
@@ -224,44 +226,6 @@ select {
 
 body {
   overflow-x: hidden;
-}
-
-body.dark-mode {
-  background-color: #121212;
-  color: #ffffff;
-}
-
-body.dark-mode .h1,
-body.dark-mode .h2,
-body.dark-mode .h3 {
-  color: #ffffff;
-  margin: 0 10px;
-}
-
-.container00.dark-mode,
-.container01.dark-mode {
-  background-color: #1e1e1e;
-  color: #ffffff;
-}
-
-.section-subtitle.dark-mode,
-.h2.section-title.has-underline.dark-mode {
-  color: #ffffff;
-}
-
-.btn-primary.dark-mode {
-  background-color: #333333;
-  color: #ffffff;
-  border: 1px solid #ffffff;
-}
-
-.book-info.dark-mode {
-  background-color: #2c2c2c;
-  color: #ffffff;
-}
-
-.book-image.dark-mode {
-  border: 1px solid #ffffff;
 }
 
 .cards {
@@ -472,7 +436,7 @@ body.dark-mode .h3 {
   perspective: 600px;
 }
 
-.booki{
+.booki {
   position: relative;
   margin: 10px;
   transform: rotateY(-30deg);
@@ -480,7 +444,8 @@ body.dark-mode .h3 {
   transition: transform 1s ease;
   animation: 1s ease 0s 1 initAnimation;
 }
-.booki img{
+
+.booki img {
   border-top-right-radius: 5px;
   border-bottom-right-radius: 5px;
   border-bottom-left-radius: 3px;
@@ -489,6 +454,7 @@ body.dark-mode .h3 {
   width: 100%;
   box-shadow: 0px 1px 10px #666;
 }
+
 .booki:hover {
   transform: rotate(0deg);
 }
@@ -497,12 +463,13 @@ body.dark-mode .h3 {
   0% {
     transform: rotateY(0deg);
   }
+
   100% {
     transform: rotateY(-30deg);
   }
 }
 
-.booki::before{
+.booki::before {
   content: '';
   background: #fff;
   position: absolute;
@@ -512,11 +479,13 @@ body.dark-mode .h3 {
   right: 0px;
   transform: translateX(25%) rotateY(90deg) translateX(calc(50px / 2));
 }
-.booki::after{
+
+.booki::after {
   content: ' ';
   position: absolute;
-  top:0px;
-  left: 0;width: 98%;
+  top: 0px;
+  left: 0;
+  width: 98%;
   height: 93%;
   border-top-right-radius: 3px;
   border-bottom-right-radius: 3px;
@@ -524,18 +493,23 @@ body.dark-mode .h3 {
   transform: translateZ(-50px);
   box-shadow: -10px 0 40px 10px #6666664c;
 }
-#b2 .booki::after{
+
+#b2 .booki::after {
   background: #c48827b9;
 }
-#b3 .booki::after{
+
+#b3 .booki::after {
   background: #6e4201b9;
 }
-#b4 .booki::after{
+
+#b4 .booki::after {
   background: #010379b9;
 }
-#b5 .booki::after{
+
+#b5 .booki::after {
   background: #3b1600b9;
 }
+
 .preview-button {
   position: absolute;
   background-color: hwb(357 6% 36% / 0.738);
@@ -565,6 +539,57 @@ body.dark-mode .h3 {
   font-size: 45px;
 
 
+}
+
+body.dark-mode {
+  background-color: #121212;
+  color: #ffffff;
+}
+
+body.dark-mode .h1,
+body.dark-mode .h2,
+body.dark-mode .h3 {
+  color: #ffffff;
+  margin: 0 10px;
+}
+
+.container00.dark-mode,
+.container01.dark-mode {
+  background-color: #1e1e1e;
+  color: #ffffff;
+}
+
+.section-subtitle.dark-mode,
+.h2.section-title.has-underline.dark-mode {
+  color: #ffffff;
+}
+
+.btn-primary.dark-mode {
+  background-color: #333333;
+  color: #ffffff;
+  border: 1px solid #ffffff;
+}
+
+.book-info.dark-mode {
+  background-color: #2c2c2c;
+  color: #ffffff;
+}
+
+.book-image.dark-mode {
+  border: 1px solid #ffffff;
+}
+
+.dark-mode .preference-bar label,
+.dark-mode .preference-bar select:hover,
+.dark-mode .container00 h2,
+.dark-mode #recommendationTitle,
+.dark-mode .trending {
+  color: white;
+  /* Color for dark mode */
+}
+
+.dark-mode .section-subtitle {
+  color: rgb(255, 212, 212);
 }
 
 @media only screen and (max-width:700px) {


### PR DESCRIPTION
# Related Issue
BUG: Dark Mode Title Color on Book Recommendation Page 

Fixes:  #2605  

# Description
On the book recommendation page the color of "Trending books" and "book recommendation" title is fixed to change in  light/dark mode and is made consistent to the UI design.

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Before in dark mode: 
<img width="626" alt="image" src="https://github.com/user-attachments/assets/7250ab1e-a9a1-4bc3-9b70-06b86cb72d5b">
<img width="650" alt="image" src="https://github.com/user-attachments/assets/b713d029-24e8-451c-a658-52c513dc3cfb">

After Changes:

https://github.com/user-attachments/assets/8e243daf-e978-4d69-8e38-460ce15cd02b


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

