### PR TITLE
fix: center genre heading on large screens (#2672).

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1128,6 +1128,10 @@ body.dark-mode .chapter-card:hover {
 #genre .section-subtitle {
   margin-top: 20px;
   margin-bottom: 20px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 #genre .grid-list {
   margin-top: 30px;


### PR DESCRIPTION
## Related Issue

 Fixes: #2672

## Description
  Centered the genre section heading for large screens .
  Fixes: #2672 


# Type of PR

- [x] Bug fix

# Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes. Make sure to attach before & after screenshots in your PR.]
### Before:
![Screenshot 2024-07-28 142622](https://github.com/user-attachments/assets/df18cdf8-f8c3-48e5-af6b-eb7678afaadf)

### After:
![Screenshot 2024-07-28 142638](https://github.com/user-attachments/assets/c52f8cee-497a-4ac5-a82b-eb176500bf85)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.]
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

