### PR TITLE
Changed Titles of Cost efficient page and Environmental-impact page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1272,6 +1272,11 @@ body.dark-mode .chapter-card:hover {
   padding-block: 10px;
 }
 
+.pricing-card .btn:hover {
+  color: darkred;
+  background-color: white;
+}
+
 .pricing-card .btn {
   margin-inline: auto;
   align-self: center;

--- a/costefficient.html
+++ b/costefficient.html
@@ -3,6 +3,7 @@
    <head>
        <meta charset="UTF-8">
        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+       <title>Cost Efficient - SwapReads</title>
        <link rel="apple-touch-icon" sizes="180x180" href="./assets/favicon_package_v0.16/apple-touch-icon.png">
        <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon_package_v0.16/favicon-32x32.png">
        <link rel="icon" type="image/png" sizes="16x16" href="./assets/favicon_package_v0.16/favicon-16x16.png">

--- a/environmental-impact.html
+++ b/environmental-impact.html
@@ -3,6 +3,7 @@
    <head>
        <meta charset="UTF-8">
        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+       <title>Environmental Impact - SwapReads</title>
        <link rel="apple-touch-icon" sizes="180x180" href="./assets/favicon_package_v0.16/apple-touch-icon.png">
        <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon_package_v0.16/favicon-32x32.png">
        <link rel="icon" type="image/png" sizes="16x16" href="./assets/favicon_package_v0.16/favicon-16x16.png">


### PR DESCRIPTION
# Related Issue

None

Fixes:  #2769 

# Description

The Titles of Cost Efficient Page and Environmental Impact Page were not correct.

Issue- #2769 

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Before:
![image](https://github.com/user-attachments/assets/07112003-eb41-406f-bfe4-7006a6e20b8d)

![image](https://github.com/user-attachments/assets/93bac1a2-e61f-4a5d-ae90-def6080c64a3)


After:
![image](https://github.com/user-attachments/assets/990211ec-ba0d-48dd-a40b-51458d1e6bf2)

![image](https://github.com/user-attachments/assets/bb117c0b-f4a3-433e-a5d4-2cd00d9e069f)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

