### PR TITLE
Button padding fix issue#2915

### DIFF
--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -234,6 +234,11 @@ iframe {
     margin: 4px 4px;
     background-color: rgb(240, 15, 15);
 }
+
+.read_later_button {
+            padding: 10px; /* Adjust the padding value as needed */
+}
+
 @media only screen and (max-width:1063px){
     .nav{
         flex-direction: column;
@@ -805,7 +810,7 @@ this.style.display = "none";
                 <img id="open-modal6" src="https://th.bing.com/th/id/OIP.i4wGILb5pOCB68s5SDIMcwHaLH?rs=1&pid=ImgDetMain" alt="Oliver Twist" class="book-cover">
                 <h3 class="book_title">Oliver Twist</h3>
                 <a href="https://www.gutenberg.org/ebooks/730" class="btn btn-secondary">Download</a>
-                <button onclick="addToReadLater(6)" class="read_later_button">Add to Read Later</button>
+                <button onclick="addToReadLater(6)" class="read_later_button" >Add to Read Later</button>
             </div>
              <!-- code to add preview to the book image -->
              <div id="previewmodal2" class="premodal">
@@ -838,7 +843,7 @@ this.style.display = "none";
                 <img id="open-modal7"src="https://th.bing.com/th/id/OIP.S0qQ8zdSHnFSzr-14H0KnAAAAA?rs=1&pid=ImgDetMain" alt="The Hunger Games" class="book-cover">
                 <h3 class="book_title">The Hunger Games</h3>
                 <a href="https://archive.org/details/the-hunger-games-pdf-download" class="btn btn-secondary">Download</a>
-                <button onclick="addToReadLater(7)" class="read_later_button">Add to Read Later</button>
+                <button onclick="addToReadLater(7)" class="read_later_button" >Add to Read Later</button>
             </div>
              <!-- code to add preview to the book image -->
              <div id="previewmodal2" class="premodal">

--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -236,7 +236,7 @@ iframe {
 }
 
 .read_later_button {
-            padding: 10px; /* Adjust the padding value as needed */
+            padding: 10px; 
 }
 
 @media only screen and (max-width:1063px){


### PR DESCRIPTION
# Related Issue

None

Fixes:  #2915 

# Description

Fixed padding around add to read later button in free e-books page

<!---give the issue number you fixed----->

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
![image](https://github.com/user-attachments/assets/eeb241e1-787b-411f-9591-dd8d5931fb67)

# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.


