### PR TITLE
refresher refresh on click fix #2863

### DIFF
--- a/assets/js/refresher.js
+++ b/assets/js/refresher.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     const caduceus = document.getElementById('caduceus');
     
-    caduceus.addEventListener('mouseover', function() {
+    caduceus.addEventListener('click', function() {
       location.reload();
     });
   });


### PR DESCRIPTION
# Issue

When the profile page is opened, if the mouse accidentally hovers over the hanging book icon (which is currently functioning as a page refresher), the website refreshes automatically without any user action. This can disrupt the user experience, especially if it happens unintentionally.

Fixes:  2863

# Description

it should only trigger a page refresh when clicked, not on hover . And I Changed it accordingly.

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.

