### PR TITLE
image in contact us was compress and was looking bad now it is …

### DIFF
--- a/index.html
+++ b/index.html
@@ -3191,10 +3191,10 @@ body > .skiptranslate {
           <button type="submit">Send Message</button>
         </form>
         <div class="image-fader">
-          <img src="/assets/images/ctc1.png" alt="ctc1">
-          <img src="/assets/images/ctc5.png" alt="ctc5">
-          <img src="/assets/images/ctc3.png" alt="ctc3">
-          <img src="/assets/images/ctc4.png" alt="ctc4">
+          <img src="/SwapReads/assets/images/ctc1.png" alt="ctc1">
+          <img src="/SwapReads/assets/images/ctc2.png" alt="ctc2">
+          <img src="/SwapReads/assets/images/ctc3.png" alt="ctc3">
+          <img src="/SwapReads/assets/images/ctc4.png" alt="ctc4">
         </div>
       </div>
     </div>


### PR DESCRIPTION

 
Fixes: #2980 

Description
This pull request addresses the issue of the compressed image in the "Contact Us" section, which resulted in a poor visual appearance. The image has now been corrected to ensure it displays clearly and maintains its intended quality.

Motivation and Context
The motivation for this change was to enhance the user experience by ensuring that all images, particularly in key sections like "Contact Us," are displayed at their best quality. This helps in presenting a professional and visually appealing interface.

Dependencies
No additional dependencies are required for this change.

Type of PR
 Bug fix
  
Screenshots / videos  
Before:

https://github.com/user-attachments/assets/94ef6818-189a-4e18-9c04-9abad23a9174



After:

https://github.com/user-attachments/assets/9ed11329-0fb1-4eb9-91ef-c39f5cff08c8



Checklist:
 I have made this change from my own.
 My code follows the style guidelines of this project.
 I have performed a self-review of my own code.
 I have commented my code, particularly in hard-to-understand areas.
 My changes generate no new warnings.
 I have tested the changes thoroughly before submitting this pull request.
 I have provided relevant issue numbers and screenshots after making the changes.