### PR TITLE
Fixed sidebar background on smaller screens for better readability

### DIFF
--- a/assets/css/aboutus.css
+++ b/assets/css/aboutus.css
@@ -308,6 +308,7 @@ label.newsletter-form{
     max-height: unset;
     transition: 0.3s ease-in;
     border: none;
+    background-color: #ffffff;
   }
   /* body .nav_activated{
     transform:translateX(-200%)


### PR DESCRIPTION
This pull request fixes the issue where the sidebar text becomes unreadable on smaller screens due to the lack of a background color. A white background (`#ffffff`) has been added to the sidebar for small screen sizes, ensuring better contrast and readability.

Fixes: #2997 

**Changes Made**:
- Added a CSS rule to apply a white background to the sidebar when the screen width is below a certain threshold

**Screenshots**:
before: 
<img width="160" alt="Screenshot 2024-10-05 at 11 30 22 PM" src="https://github.com/user-attachments/assets/cdd0a1e1-deb3-4d27-b3b6-5ab63163d2e9">
after:
<img width="164" alt="Screenshot 2024-10-05 at 11 37 44 PM" src="https://github.com/user-attachments/assets/05a381d3-f47e-45cf-8d55-550ce6af5e9f">


**Testing**:
- Tested on different screen sizes to ensure the sidebar background color is applied correctly on smaller screens.

