### PR TITLE
Fixed issue #3043: Overlapping of the address section with the Get in Touch Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -3089,6 +3089,13 @@ body > .skiptranslate {
     margin-bottom: 17px;
     
 }
+.cardi{
+    display: flex;
+    justify-content: center; /* Center the contact card */
+    align-content: center;
+    margin-top: 200px; /* Adjust this value as needed */
+    margin-left:280px;
+}
 
 
   <section class="section-contact" id="contact" aria-label="contact">


### PR DESCRIPTION
Overlapping of Get in Touch and Address sections was fixed.

# Related Issue

None

Fixes:  #3043 

# Description

The Get in Touch Section was overlapping with the Address Section,which was fixed.

<!---Fixed:#3043----->

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
After:
<img width="1021" alt="Screenshot 2024-10-07 at 3 10 06 PM" src="https://github.com/user-attachments/assets/cd2336a0-8253-4578-943c-36a85d8f32e4">
Before:
<img width="696" alt="Screenshot 2024-10-07 at 3 10 28 PM" src="https://github.com/user-attachments/assets/d1e6259d-6580-4ba1-8558-71c644e3ad3d">


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

