### PR TITLE
unnecessary arrows were present are removed #2864

### DIFF
--- a/index.html
+++ b/index.html
@@ -3509,10 +3509,6 @@ $('.dropdown-menu').on('scroll', function(event) {
     <span class="span has-before"></span>
   </h2>
   <p class="section-subtitle" style="text-align: center;">Know what our customers say</p>
-  <div class="swiper-navigation">
-  <button class="swiper-button-prev custom-prev">❮</button>
-  <button class="swiper-button-next custom-next">❯</button>
-</div>
   <swiper-container class="mySwiper" pagination="true" pagination-clickable="true" navigation="true" space-between="40"
     loop="true" >
     <swiper-slide>


### PR DESCRIPTION
# Related Issue

There are unnecessary arrows visible on both the left and right sides of the image in the UI, which are not needed and clutter the design. These arrows don't seem to serve any functional purpose and can confuse the user. This affects the visual appearance of the page and might distract users from the main content.

Fixes:  #2956

# Description

Remove the unnecessary arrows from both sides of the image to improve the design and user experience.
#2956 

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________


