### PR TITLE
fixed overlaping elements in booklistswap

### DIFF
--- a/assets/html/booklistswap.html
+++ b/assets/html/booklistswap.html
@@ -324,6 +324,7 @@
       text-decoration: none;
       width: 500px;
       text-align: center;
+      margin-top: 12rem;
     }
 
     #a {


### PR DESCRIPTION
# Related Issue


Fixes:  #3121 

# Description
On the book list swapping page, the Navbar overlaps with the "Add Book" window, making it difficult to interact with the form elements and properly view the content. This leads to a poor user experience as the "Add Book" window is partially hidden behind the Navbar.


<!---give the issue number you fixed----->

# Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Before:
![Screenshot 2024-10-08 184434](https://github.com/user-attachments/assets/682c1e95-fbda-454f-bdca-5e18f4cc2e9a)
After:
![Screenshot 2024-10-08 185858](https://github.com/user-attachments/assets/c76bae63-191d-4afe-88aa-6667a7ba0a10)



# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

