### PR TITLE
Changed Position of Profile Avatar

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -572,6 +572,7 @@ body {
   border-radius: 50%;
   overflow: hidden;
   cursor: pointer;
+  right: 8rem;
 }
 
 .action .profile img {


### PR DESCRIPTION
# Related Issue


Fixes:  #3128 

# Description

In the current implementation of the homepage, the profile avatar overlaps with the theme switch button, causing a poor user experience. This issue arises from the CSS positioning and spacing of these two elements, which results in them not being properly aligned.

<!---give the issue number you fixed----->

# Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Befor:
![Screenshot 2024-10-08 205827](https://github.com/user-attachments/assets/2444179c-cecc-446e-b6c4-ae05be0129e0)
After:
![Screenshot 2024-10-08 211325](https://github.com/user-attachments/assets/818226e6-962a-412a-924a-e0f3016704ad)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

