### PR TITLE
Fix more Dropdown button in community page.

### DIFF
--- a/comsp.html
+++ b/comsp.html
@@ -797,7 +797,7 @@ color: #d26d6d;
               
                           lastScrollTop = scrollTop;
                       });
-                  </>
+                  </script>
       
 
                

--- a/comsp.html
+++ b/comsp.html
@@ -756,6 +756,8 @@ color: #d26d6d;
                       </ul>
                   </div>
               </div>
+
+              
               
                     <script>
                       document.addEventListener("DOMContentLoaded", () => {
@@ -795,7 +797,7 @@ color: #d26d6d;
               
                           lastScrollTop = scrollTop;
                       });
-                  </script>
+                  </>
       
 
                
@@ -805,6 +807,14 @@ color: #d26d6d;
     </div>
 
     <script src="http://translate.google.com/translate_a/element.js?cb=loadGoogleTranslate"></script>
+    <script>
+                document.getElementById("more-link").addEventListener("click", function (event) {
+  event.preventDefault();  // Prevent the default behavior of the link
+  const dropdownMenu = document.getElementById("dropdown-menu");
+  dropdownMenu.classList.toggle("active");  // Toggle the visibility of the dropdown menu
+});
+
+              </script>
     <script>
         function loadGoogleTranslate() {
             new google.translate.TranslateElement({


### PR DESCRIPTION
# Related Issue
In Community Spotlight page the dropdown button in header is now working.

Fixes:  #3143 

# Description

As you can see when an user click on more dropdown button in community spotlight page its not working so i fix this issue also having some closing tag issue in spotlight community page which i have fixed it properly.


# Type of PR

- [ ] Bug fix
- [ ] Feature enhancement

# Screenshots / videos (if applicable)

Before Coomunity page drodown button which is not orking on click

https://github.com/user-attachments/assets/f0bf2005-589a-4c34-8f3a-05a4fd976008



After fix the More dropdown button button issue in Community Spotlight page.

![Screenshot 2024-10-09 104924](https://github.com/user-attachments/assets/d071feb4-0078-48a9-a5d6-31ce49d97170)


# Checklist:
- [ ] I have made this change from my own.
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers and screenshots after making the changes.

