### PR TITLE
Fix Community Chat page navigation issue page not found.

### DIFF
--- a/assets/html/about.html
+++ b/assets/html/about.html
@@ -395,7 +395,7 @@
 
               <ul class="dropdown-menu-list">
                 <li>
-                  <a href="chat.html" class="navbar-link"
+                  <a href="../../chat.html" class="navbar-link"
                     style="font-family: sans-serif; color: black; margin-bottom: 5px;">
                     Community chat
                   </a>


### PR DESCRIPTION
# Related Issue
As you can see when i click on Community Chat nav_button under header more section it shows page not found error. i want to fix this issue.



Fixes:  #3145 

# Description
As you can see when i click on Community Chat nav_button under header more section it shows page not found error, but now i have fixed the issue and its navigation button navigate to the correct page.



# Type of PR

- [ ] Bug fix
- [ ] Feature enhancement


# Screenshots / videos (if applicable)

https://github.com/user-attachments/assets/60c5364a-88c8-4add-a83f-a079fbae8475

As you can see before Cummunication Chat Navigation link not working having issue.


After fix issue

https://github.com/user-attachments/assets/dd3d9891-5379-4201-8149-ea3bfc77426f



# Checklist:
- [ ] I have made this change from my own.
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers and screenshots after making the changes.

