### PR TITLE
Fix the dropdown navigation link button issue

### DIFF
--- a/assets/html/about.html
+++ b/assets/html/about.html
@@ -427,7 +427,7 @@
                       class="ri-price-tag-3-fill"></i>Read Later</a>
                 </li>
                 <li class="dropdown-menu-item">
-                  <a href=".../html/ConnReader.html" class="navbar-link" data-nav-link><i
+                  <a href="./ConnReader.html" class="navbar-link" data-nav-link><i
                       class="ri-price-tag-3-fill"></i>Reader Connection</a>
                 </li>
                 <li class="dropdown-menu-item">


### PR DESCRIPTION
In dropdown button navigation is not properly done. Its shows error page not found when click on nav_button.

Fixes: #3161 

# Description

As you can see in video when user click on navigation button in dropdown menu it shows an eroor of page not found so i fix the navigation link button to navigate correct page.


# Type of PR

- [ ] Bug fix
- [ ] Feature enhancement


# Screenshots / videos (if applicable)
Before Issue page not found.

https://github.com/user-attachments/assets/08f9a7ba-4de4-464a-8ff0-64f62de77937


After issue fix

https://github.com/user-attachments/assets/ade187b5-eb1f-47be-b5e1-ca321cce82b6





# Checklist:
- [ ] I have made this change from my own.
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers and screenshots after making the changes.

