### PR TITLE
Updated cookie pop up

### DIFF
--- a/cookiepolicy.html
+++ b/cookiepolicy.html
@@ -61,10 +61,10 @@ li {
     <h2>Types of Cookies We Use</h2>
     <p>We use different types of cookies, including:</p>
     <ul>
-        <li>**Essential cookies:** These cookies are necessary for the website to function properly.</li>
-        <li>**Performance cookies:** These cookies collect information about how you use our website, such as which pages you visit and how long you spend on them.</li>
-        <li>**Functional cookies:** These cookies allow us to remember your preferences, such as your language settings.</li>
-        <li>**Targeting cookies:** These cookies are used to deliver relevant ads to you.</li>
+        <li>Essential cookies: These cookies are necessary for the website to function properly.</li>
+        <li>Performance cookies: These cookies collect information about how you use our website, such as which pages you visit and how long you spend on them.</li>
+        <li>Functional cookies: These cookies allow us to remember your preferences, such as your language settings.</li>
+        <li>Targeting cookies: These cookies are used to deliver relevant ads to you.</li>
     </ul>
 
     <h2>Managing Cookies</h2>

--- a/cookiepolicy.html
+++ b/cookiepolicy.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cookie Policy</title>
+
+    <style>
+        body {
+    font-family: Arial, sans-serif;
+    line-height: 1.5;
+    margin: 20px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100%25' height='100%25' viewBox='0 0 1600 800'%3E%3Cg %3E%3Cpath fill='%23ffb9b0' d='M486 705.8c-109.3-21.8-223.4-32.2-335.3-19.4C99.5 692.1 49 703 0 719.8V800h843.8c-115.9-33.2-230.8-68.1-347.6-92.2C492.8 707.1 489.4 706.5 486 705.8z'/%3E%3Cpath fill='%23ffc1b7' d='M1600 0H0v719.8c49-16.8 99.5-27.8 150.7-33.5c111.9-12.7 226-2.4 335.3 19.4c3.4 0.7 6.8 1.4 10.2 2c116.8 24 231.7 59 347.6 92.2H1600V0z'/%3E%3Cpath fill='%23ffc8bf' d='M478.4 581c3.2 0.8 6.4 1.7 9.5 2.5c196.2 52.5 388.7 133.5 593.5 176.6c174.2 36.6 349.5 29.2 518.6-10.2V0H0v574.9c52.3-17.6 106.5-27.7 161.1-30.9C268.4 537.4 375.7 554.2 478.4 581z'/%3E%3Cpath fill='%23ffcfc6' d='M0 0v429.4c55.6-18.4 113.5-27.3 171.4-27.7c102.8-0.8 203.2 22.7 299.3 54.5c3 1 5.9 2 8.9 3c183.6 62 365.7 146.1 562.4 192.1c186.7 43.7 376.3 34.4 557.9-12.6V0H0z'/%3E%3Cpath fill='%23FFD6CE' d='M181.8 259.4c98.2 6 191.9 35.2 281.3 72.1c2.8 1.1 5.5 2.3 8.3 3.4c171 71.6 342.7 158.5 531.3 207.7c198.8 51.8 403.4 40.8 597.3-14.8V0H0v283.2C59 263.6 120.6 255.7 181.8 259.4z'/%3E%3Cpath fill='%23ffdcd4' d='M1600 0H0v136.3c62.3-20.9 127.7-27.5 192.2-19.2c93.6 12.1 180.5 47.7 263.3 89.6c2.6 1.3 5.1 2.6 7.7 3.9c158.4 81.1 319.7 170.9 500.3 223.2c210.5 61 430.8 49 636.6-16.6V0z'/%3E%3Cpath fill='%23ffe1d9' d='M454.9 86.3C600.7 177 751.6 269.3 924.1 325c208.6 67.4 431.3 60.8 637.9-5.3c12.8-4.1 25.4-8.4 38.1-12.9V0H288.1c56 21.3 108.7 50.6 159.7 82C450.2 83.4 452.5 84.9 454.9 86.3z'/%3E%3Cpath fill='%23ffe6df' d='M1600 0H498c118.1 85.8 243.5 164.5 386.8 216.2c191.8 69.2 400 74.7 595 21.1c40.8-11.2 81.1-25.2 120.3-41.7V0z'/%3E%3Cpath fill='%23ffebe4' d='M1397.5 154.8c47.2-10.6 93.6-25.3 138.6-43.8c21.7-8.9 43-18.8 63.9-29.5V0H643.4c62.9 41.7 129.7 78.2 202.1 107.4C1020.4 178.1 1214.2 196.1 1397.5 154.8z'/%3E%3Cpath fill='%23FFF0EA' d='M1315.3 72.4c75.3-12.6 148.9-37.1 216.8-72.4h-723C966.8 71 1144.7 101 1315.3 72.4z'/%3E%3C/g%3E%3C/svg%3E");
+  background-attachment: fixed;
+  background-size: cover;
+  color: var(--sonic-silver);
+}
+
+h1 {
+    font-size: 24px;
+    margin-bottom: 15px;
+    color: brown;
+}
+
+h2 {
+    font-size: 18px;
+    margin-bottom: 10px;
+    color: brown;
+}
+
+p {
+    margin-bottom: 15px;
+}
+
+ul {
+    margin-left: 20px;
+}
+
+li {
+    margin-bottom: 5px;
+}
+    </style>
+</head>
+<body>
+    <h1>Cookie Policy</h1>
+
+    <p>This Cookie Policy explains how "SwapReads" uses cookies and similar technologies on our website.</p>
+
+    <h2>What are Cookies?</h2>
+    <p>Cookies are small text files that are placed on your device when you visit a website. They help websites remember information about your visit, such as your preferences, language settings, and login details.</p>
+
+    <h2>How We Use Cookies</h2>
+    <p>We use cookies for various purposes, including:</p>
+    <ul>
+        <li>Improving your user experience</li>
+        <li>Analyzing website traffic</li>
+        <li>Personalizing content and ads</li>
+        <li>Enabling certain website features</li>
+    </ul>
+
+    <h2>Types of Cookies We Use</h2>
+    <p>We use different types of cookies, including:</p>
+    <ul>
+        <li>**Essential cookies:** These cookies are necessary for the website to function properly.</li>
+        <li>**Performance cookies:** These cookies collect information about how you use our website, such as which pages you visit and how long you spend on them.</li>
+        <li>**Functional cookies:** These cookies allow us to remember your preferences, such as your language settings.</li>
+        <li>**Targeting cookies:** These cookies are used to deliver relevant ads to you.</li>
+    </ul>
+
+    <h2>Managing Cookies</h2>
+    <p>You can manage your cookie preferences through your browser settings. You can also choose to delete existing cookies or disable future cookies.</p>
+
+    <h2>Changes to Our Cookie Policy</h2>
+    <p>We may update our Cookie Policy from time to time. Any changes will be posted on this page.</p>
+
+    <p>If you have any questions about our Cookie Policy, please contact us at support@swapreads.com</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -547,16 +547,15 @@
 
     #cookie-consent {
   position: fixed;
-  bottom: 1rem;
-  left: 1rem;
   background-color: #f1f1f1;
-  padding: 2rem;
+  padding: 10px 15px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  align-items: center;
-  width: 30rem;
-  height: fit-content;
+  bottom: 15px;
+  left: 20px;
+  width: 300px;
+  height: 250px;
   z-index: 10000;
   border-radius: 1rem;
   margin-bottom: 5rem;
@@ -564,7 +563,10 @@
   border-right: 0.4rem solid transparent;
   border-bottom: 0.4rem solid transparent;
   transition: border-color 0.3s;
+  font-size: 12px;
 }
+    
+
 
 #cookie-consent:hover {
   border-right-color: #A30F17;
@@ -572,8 +574,20 @@
 }
 
 #cookie-consent p {
-  color: black;  /* Make the text black for better visibility */
-  text-align: center;  /* Center align the text */
+  color: rgb(78, 7, 7);  /* Make the text black for better visibility */
+  margin: 10px opx;  /* Center align the text */
+}
+
+#cookie-container a {
+    color: rgb(78, 7, 7);
+    text-decoration: none;
+}
+
+#cookie-consent button {
+    padding: 10px 15px;
+    border: none;
+    cursor: pointer;
+    font-size: 13px;
 }
 
 .accept-cookies,
@@ -582,6 +596,7 @@
   height: 3.5rem;  /* Decrease the button height */
   color: white;
   background-color: #A30F17;
+  font-size: 12px;
   border: none;
   border-radius: 0.5rem;  /* Add rounded corners */
   cursor: pointer;
@@ -615,19 +630,6 @@
 .reject-cookies:hover {
   background-color: rgb(250, 192, 192);
   color: #A30F17;
-}
-
-#learn-more-link,
-#show-less-link {
-  color: #A30F17; 
-  text-decoration: none;
-  cursor: pointer;
-  font-size: 2rem;
-}
-
-#learn-more-link:hover,
-#show-less-link:hover {
-  text-decoration: underline; 
 }
 
 #cookie-content {
@@ -1452,18 +1454,14 @@ iframe {
 </div>
 
   <div id="cookie-consent">
-    <button class="close-btn" id="closeBtn" style="padding: 0.5rem; height: 4rem; width: 4rem; border-radius: 100%; font-size: 3rem;" >&times;</button>
+    <button class="close-btn" id="closeBtn" style="position: absolute; border-radius: 100%; top: 10px; right: 10px; font-size: 2rem; cursor: pointer;" >&times;</button>
+    <p >We value your privacy</p>
     <p>
-        We use cookies to improve your experience. By using our website, you consent to all cookies in accordance with our Cookie Policy.
-        <a href="#" id="learn-more-link">Learn More</a>
-
+      <br>
+      We use cookies to enhance your browsing experience, serve personalized ads or content, and analyze our traffic.
+      By clicking "Accept", you consent to our use of cookies.
+        <a href="cookiepolicy.html" style="color: #d4151f; text-decoration: underline; font-size: small;">Cookie Policy</a>
     </p>
-    <div id="learn-more-content" style="display: none;">
-        <p>Cookies are small text files that can be used by websites to make a user's experience more efficient. The law states that we can store cookies on your device if they are strictly necessary for the operation of this site. For all other types of cookies we need your permission.</p>
-        <p>This site uses different types of cookies. Some cookies are placed by third party services that appear on our pages.</p>
-    </div>
-
-    <a href="#" id="show-less-link" style="display: none;">Show Less</a>
     <button class="accept-cookies">Accept</button>
     <button class="reject-cookies">Reject</button>
   </div>
@@ -1478,8 +1476,6 @@ iframe {
   const cookieConsent = document.getElementById('cookie-consent');
   const acceptButton = document.querySelector('.accept-cookies');
   const rejectButton = document.querySelector('.reject-cookies');
-  const learnMoreLink = document.getElementById('learn-more-link');
-  const learnMoreContent = document.getElementById('learn-more-content');
 
   // Hide preloader after page load
   window.addEventListener('load', function() {
@@ -1526,13 +1522,6 @@ iframe {
     // Hide consent if localStorage is not available
     cookieConsent.style.display = 'none';
   }
-
-  // Add event listener to "Learn More" link
-  learnMoreLink.addEventListener('click', function(event) {
-    event.preventDefault();
-    learnMoreContent.style.display = 'block';
-    learnMoreLink.style.display = 'none';
-  });
 });
 </script>
   <header class="header header-anim nav-h" data-header>


### PR DESCRIPTION
# Related Issue

cookie pop up was big and occupied more space on website and on clicking "learn more" the policies could not be read properly

# Description

made the pop up a bit smaller and compact.
![image](https://github.com/user-attachments/assets/ae26ac1c-e327-49b8-add6-7d81ca3428bf)

And on clicking the 'Cookie Policy' link a new page opens which tells the cookie policy.
![image](https://github.com/user-attachments/assets/5f92317e-4f82-4939-aafa-d9c6f78d4a68)

Issue: #3227 

# Type of PR

- [] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [] I have made this change from my own.
- [] I have taken help from some online resources.
- [] My code follows the style guidelines of this project.
- [] I have performed a self-review of my own code.
- [] I have commented my code, particularly in hard-to-understand areas.
- [] I have made corresponding changes to the documentation.
- [] My changes generate no new warnings.
- [] I have tested the changes thoroughly before submitting this pull request.
- [] I have provided relevant issue numbers and screenshots after making the changes.

