### PR TITLE
fixed overlapping items

### DIFF
--- a/assets/html/about.html
+++ b/assets/html/about.html
@@ -88,6 +88,7 @@
       border-radius: 50%;
       overflow: hidden;
       cursor: pointer;
+      right: 7rem;
     }
 
     .action .profile img {


### PR DESCRIPTION
# Related Issue

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

Fixes:  #3256 

# Description

On the "About Us" page, the theme switch button is overlapping with the avatar, causing visual clutter and making it difficult for users to toggle the theme.

<!---give the issue number you fixed----->

# Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Before:
![Screenshot 2024-10-11 210155](https://github.com/user-attachments/assets/3a59e1d6-5806-4745-b710-1ceccc32faf3)
After:
![Screenshot 2024-10-11 211842](https://github.com/user-attachments/assets/ad75ffee-62ae-457d-9ffa-1e34bed127cd)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

