### PR TITLE
Fixed Background Color of rate-us

### DIFF
--- a/index.html
+++ b/index.html
@@ -3133,7 +3133,7 @@ iframe {
 }
 
 #rate-us:hover {
-  background-color: #fde2e2;  
+  background-color: #A30F17;  
   color: white;  
 } /* Closing brace for #rate-us:hover */
 


### PR DESCRIPTION
# Related Issue

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

Fixes:  #3268 

# Description

When hovering over the "Rate Us" window, the background color changes to white, causing the text to become invisible or difficult to read due to insufficient contrast between the background and the text color. This negatively affects the user experience as the text should remain visible regardless of hover interactions.

<!---give the issue number you fixed----->

# Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Before:
![Screenshot 2024-10-11 230917](https://github.com/user-attachments/assets/dd7b4a6c-5d8a-4faf-8707-07e4175b41f8)
After:
![Screenshot 2024-10-12 131122](https://github.com/user-attachments/assets/dabae11f-c98b-4839-953a-d8807940437b)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

