### PR TITLE
fix: Validate Contact Us Name Field to Accept Only Letters

### DIFF
--- a/index.html
+++ b/index.html
@@ -5083,7 +5083,8 @@ iframe {
       <div class="contact-container">
         <form class="contact-form" id="contactForm" style=" width: 500px;">
           <label for="name">Name</label>
-          <input type="text" id="name" name="name" placeholder="Your Name" required>
+          <input type="text" id="name" name="name" placeholder="Your Name" required required pattern="[a-zA-Z ]+" oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed')" 
+          oninput="this.setCustomValidity('')">
 
           <label for="email">Email</label>
           <input type="email" id="email" name="email" placeholder="your-email@example.com" required>


### PR DESCRIPTION
### Title of the Pull Request

Validate the Contact Us section's Name Field to Accept Only Letters.

Closes: #3362 

### Description
This PR addresses Issue #3362 by implementing validation on the Contact Us form's Name field to only accept alphabetical letters.

### Type of change

Added validation using the setCustomValidity method.

![image](https://github.com/user-attachments/assets/715c4147-71f7-4969-aad8-6a12d12c91a8)


**Checkbox:-**

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist

- [x] My code follows the code style of this project.
- [x] I have followed the contribution guidelines
- [x] I have performed a self-review of my own code.
- [x] I have ensured my changes don't generate any new warnings or errors.