### PR TITLE
fix: Validate Newsletter Form "Name" Field to Accept Only Letters

### DIFF
--- a/index.html
+++ b/index.html
@@ -5552,7 +5552,8 @@ iframe {
         <p>Stay updated with our latest news and offers</p>
         
         <form id="newsform" onsubmit="return showSuccessMessage();">
-            <input type="text" id="name" placeholder="Your Name" required>
+            <input type="text" id="name" placeholder="Your Name" required required pattern="[a-zA-Z ]+" oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed')" 
+            oninput="this.setCustomValidity('')">
             <input type="email" id="email" placeholder="Your Email Address" required>
             <input type="submit" value="Subscribe" name="subscribe" class="subscribe" id="subs">
         </form>


### PR DESCRIPTION
### Title of the Pull Request

Validate the Newsletter Form section's Name Field to Accept Only Letters.

Closes: #3364

### Description
This PR addresses Issue #3364 by implementing validation on the Newsletter form's Name field to only accept alphabetical letters.

### Type of change

Added validation using the setCustomValidity method.

![image](https://github.com/user-attachments/assets/1341232b-c6f8-4dcf-8aa8-161328498006)

**Checkbox:-**

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist

- [x] My code follows the code style of this project.
- [x] I have followed the contribution guidelines
- [x] I have performed a self-review of my own code.
- [x] I have ensured my changes don't generate any new warnings or errors.