### PR TITLE
Modified the transition effect for "Rate Us" section. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -4933,11 +4933,19 @@ iframe {
       <style>
 #rate-us {
   transition: background-color 0.3s ease;  
+  padding: 10px 20px;
+  background-color:  #A30F17; 
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.3s ease; 
 }
 
 #rate-us:hover {
   background-color: #A30F17;  
   color: white;  
+  transform: scale(1.1); 
 } /* Closing brace for #rate-us:hover */
 
 /* Additional styles */

--- a/index.html
+++ b/index.html
@@ -4934,7 +4934,7 @@ iframe {
 #rate-us {
   transition: background-color 0.3s ease;  
   padding: 10px 20px;
-  background-color:  #A30F17; 
+  background-color:  #b51e26; 
   color: white;
   border: none;
   border-radius: 5px;


### PR DESCRIPTION
Fixes:  #(issue no.) #3359 

# Description
The "Rate Us" section was updated with a new hover transition effect.
Before the Change: The rate us section appeared  with a transition of 0.3s ease only.
After the Change: Now, When users hover over the rate us part, it changes its background color from #b51e26 to #A30F17 and grows slightly in size. The transition lasts 0.3 seconds, providing a more dynamic and user-friendly interaction.

Here is the Video which shows you the change clearly.


https://github.com/user-attachments/assets/e66d824c-9243-49fd-bcf7-1e69f4ee91c7

Kindly requesting you to review this and merge. 

Thankyou..



