### PR TITLE
Fix: Broken Link on Profile Page

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -520,7 +520,12 @@ a {
                 <p class="profile-email"><i class="fas fa-envelope"></i> email@example.com</p>
                 <p class="profile-phone"><i class="fas fa-phone"></i> +123 456 7890</p>
                 <p class="profile-last-login" id="last-login-time">Last login: Not available</p>
-                <button class="edit-profile-btn" onclick="editProfile()"><i class="fas fa-edit"></i> Edit Profile</button>
+                <a href="./assets/html/profileedit.html">
+                    <button class="edit-profile-btn">
+                      <i class="fas fa-edit"></i> 
+                      <span>Edit Profile</span>
+                    </button>
+                  </a>
                 <div class="profile-completion">
                     <p>Profile Completion: <span id="completion-percentage">0%</span></p>
                     <div class="progress-bar-container">


### PR DESCRIPTION
# Related Issue

None

Fixes:  #3390

# Description

This PR addresses Issue #3390 by fixing the broken link on the Profile page.


# Type of PR

- [x] Bug fix

# Screenshots 

# Before -
![image](https://github.com/user-attachments/assets/6816e208-f258-422b-bf1d-6aafd5d4d3bf)

# Error / unsuccessful redirect
![image](https://github.com/user-attachments/assets/8a383782-8e60-432f-8c8b-67ad5b553191)

# After  -
![image](https://github.com/user-attachments/assets/6816e208-f258-422b-bf1d-6aafd5d4d3bf)

# successfully redirected -
![image](https://github.com/user-attachments/assets/9a4d91a2-c6cc-4739-80f4-8607415aaabd)



# Checklist:

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

