### PR TITLE
Fix: Edit Profile Form - Phone Field Validation

### DIFF
--- a/assets/html/profileedit.html
+++ b/assets/html/profileedit.html
@@ -370,6 +370,18 @@
             return re.test(email);
         }
 
+
+        /**
+         * Ensures that the phone number input field never exceeds 10 digits
+         * @param {HTMLInputElement} input The phone number input field
+         */
+         function validatePhoneInput(input) {
+            input.value = input.value.replace(/\D/g, '');
+            if (input.value.length > 10) {
+                input.value = input.value.substring(0, 10);
+            }
+        }
+        
         document.addEventListener("DOMContentLoaded", () => {
             const savedAvatar = localStorage.getItem("selectedAvatar");
             if (savedAvatar) {
@@ -393,6 +405,13 @@
             if (savedPhone) {
                 document.getElementById("phoneInput").value = savedPhone;
             }
+
+            // a JavaScript function to handle input validation
+
+            const phoneInput = document.getElementById("phoneInput");
+            phoneInput.addEventListener('input', function () {
+                validatePhoneInput(this);
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
# Related Issue

None

Fixes:  #3389

# Description

This PR addresses Issue #3389 by implementing validation on the "Phone" field in the Edit Profile page to only accept numbers (0-9).


# Type of PR

- [x] Bug fix

# Screenshots 

Before-

![image](https://github.com/user-attachments/assets/065c546d-c0d2-4cc3-af78-1bfa6ba42369)

After -

![image](https://github.com/user-attachments/assets/6007539b-9262-4f97-8834-856ca8ac0437)


# Checklist:


- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.
