### PR TITLE
size of pen icon in classic literature card is increased

### DIFF
--- a/index.html
+++ b/index.html
@@ -3958,7 +3958,7 @@ body > .skiptranslate {
                 <p class="card-subtitle">01</p>
                 <div class="iconrow">
                   <h3 class="h3 card-title">Classic Literature</h3>
-                  <span style='font: size 5rem;filter: grayscale(100%);'>&#128395;</span>
+                  <span style='font-size: 5rem;filter: grayscale(100%);'>&#128395;</span>
                 </div>
                 
 


### PR DESCRIPTION
# Related Issue

None

# Description
size of pen icon in classic literature card was not equal as that of others, I had made same size of icon

fixes issue #3679

# Type of PR

- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
![image](https://github.com/user-attachments/assets/9b8f10de-ed07-4b28-9860-dfed3e898202)

# Checklist:


- [x] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

