### PR TITLE
Fix Audio Book page navigation Error

### DIFF
--- a/audiobook.html
+++ b/audiobook.html
@@ -572,7 +572,7 @@
                 </lord-icon>Genres</a>
             </li>
             <li class="navbar-item">
-              <a href="./assets//html/about.html" class="navbar-link"
+              <a href="./assets/html/about.html" class="navbar-link"
                 >     <lord-icon
                 src="https://cdn.lordicon.com/fozsorqm.json"
                 trigger="hover"

--- a/audiobook.html
+++ b/audiobook.html
@@ -572,7 +572,7 @@
                 </lord-icon>Genres</a>
             </li>
             <li class="navbar-item">
-              <a href="../SwapReads/assets/html/about.html" class="navbar-link"
+              <a href="./assets//html/about.html" class="navbar-link"
                 >     <lord-icon
                 src="https://cdn.lordicon.com/fozsorqm.json"
                 trigger="hover"

--- a/audiobook.html
+++ b/audiobook.html
@@ -579,8 +579,7 @@
                 stroke="bold"
                 state="hover-up"
                 colors="primary:#a30f17,secondary:#e88c30"
-                style="width:30px;height:30px"></lord-icon>About</a
-              >
+                style="width:30px;height:30px"></lord-icon>About</a>
             </li>
         </ul>
       </nav>

--- a/audiobook.html
+++ b/audiobook.html
@@ -562,7 +562,7 @@
             </lord-icon>Books</a>
             </li>
             <li class="navbar-item">
-              <a href="../SwapReads/index.html#genre" class="navbar-link"
+              <a href="./index.html#genre" class="navbar-link"
                 ><script src="https://cdn.lordicon.com/lordicon.js"></script>
                 <lord-icon
                     src="https://cdn.lordicon.com/lcvlsnre.json"


### PR DESCRIPTION
# Related Issue
In Audio Book page header navigation showing error page not found.

Fixes:  #3703 


# Description
As you can see in below demo video in Audio Book page header navigation showing error page not found. So i fized the navigation issue and add correct link.



# Type of PR
- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Before

https://github.com/user-attachments/assets/4bc66ed7-efa3-4551-89a4-02ceb006a76d

After fixing the navigation page error not found


https://github.com/user-attachments/assets/1abc0c3d-6437-4b85-bc87-62e52b922dd1



# Checklist:
- [x] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

