### PR TITLE
Bug/Genre heading correction

### DIFF
--- a/index.html
+++ b/index.html
@@ -4130,8 +4130,8 @@ body > .skiptranslate {
             <li>
               <div class="chapter-card">
 
-                <p class="card-subtitle">02</p>
-                <div class="iconrow">
+                <p class="card-subtitle" style=" width: 202.48px; height: 13px;">02</p>
+                <div class="iconrow" style=" width: 202.48px; height: 79px;">
                   <h3 class="h3 card-title">Romance</h3>
                     <span style='font-size:5rem;filter: grayscale(100%);'>&#10084;</span>
                   </div>
@@ -4157,7 +4157,7 @@ body > .skiptranslate {
               <div class="chapter-card">
 
                 <p class="card-subtitle">03</p>
-                <div class="iconrow">
+                <div class="iconrow" style=" width: 202.48px; height: 79px;">
                 <h3 class="h3 card-title">Suspense Thriller</h3>
                   <span style='font-size:5rem;filter: grayscale(100%);'>&#128269;</span>
                 </div>

--- a/index.html
+++ b/index.html
@@ -4099,7 +4099,6 @@ body > .skiptranslate {
           </h2>
 
           <ul class="grid-list">
-
             <li>
               <div class="chapter-card">
 


### PR DESCRIPTION
# Related Issue

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

Fixes:  #3519

# Description

changed the heading of genre cards heading . made them on a same line in first three cards of genre section.

<!---give the issue number you fixed----->

# Type of PR

- [X] Bug fix


# Screenshots / videos (if applicable)

before:

![Screenshot 2024-10-16 094035](https://github.com/user-attachments/assets/436b16c3-b1ed-477b-a6db-d36f04990092)

after:

![Screenshot 2 -git](https://github.com/user-attachments/assets/bb851b67-c719-4ed7-abe1-92a7ee0180ee)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

