### PR TITLE
Fix: Open social media links in a new tab 

### DIFF
--- a/index.html
+++ b/index.html
@@ -2752,25 +2752,25 @@ body > .skiptranslate {
   <div class="socialmediaicons" style="z-index: 99;" >
 
     
-    <a class="active instagram" href="https://www.instagram.com/" class="" style="font-size: 2.5rem;" >
+    <a class="active instagram" href="https://www.instagram.com/" class="" style="font-size: 2.5rem;" target="_blank">
       <i class="fa-brands fa-instagram"></i>
     </a>
-    <a class="active" href="https://www.facebook.com/" class="facebook" style="font-size: 2.5rem;" >
+    <a class="active" href="https://www.facebook.com/" class="facebook" style="font-size: 2.5rem;" target="_blank">
       <i class="fa-brands fa-facebook"></i>
     </a>
-    <a class="active" href="https://www.youtube.com/" class="youtube" style="font-size: 2.5rem;" >
+    <a class="active" href="https://www.youtube.com/" class="youtube" style="font-size: 2.5rem;" target="_blank">
       <i class="fa-brands fa-youtube"></i>
     </a>
-    <a class="active linkedin" href="https://www.linkedin.com/" style="font-size: 2.5rem;">
+    <a class="active linkedin" href="https://www.linkedin.com/" style="font-size: 2.5rem;" target="_blank">
       <i class="fa-brands fa-linkedin"></i>
     </a>
-    <a class="active github" href="https://github.com/" style="font-size: 2.5rem;">
+    <a class="active github" href="https://github.com/" style="font-size: 2.5rem;" target="_blank">
       <i class="fa-brands fa-github"></i>
     </a>
-    <a class="active discord" href="https://discord.com/" style="font-size: 2.5rem; margin: 0 10px;">
+    <a class="active discord" href="https://discord.com/" style="font-size: 2.5rem; margin: 0 10px;" target="_blank">
       <i class="fa-brands fa-discord"></i>
     </a>
-    <a class="active twitter" href="https://twitter.com/" style="font-size: 2.5rem; margin: 0 10px;">
+    <a class="active twitter" href="https://twitter.com/" style="font-size: 2.5rem; margin: 0 10px;" target="_blank">
       <i class="fa-brands fa-x-twitter"></i>
     </a> 
 </div>


### PR DESCRIPTION
# Related Issue

Fixes: #3864

# Description

Added `target="_blank"` to the social media links to ensure they open in a new tab or window when clicked, preventing the user from being navigated away from the current page. This change enhances user experience and navigation. No new dependencies were introduced with this change.

#3864 

# Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)

https://github.com/user-attachments/assets/c89ec2c4-2f5e-4ac3-bace-98e47d2cbd6a

# Checklist:

- [x] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.