### PR TITLE
Back to Top button added

### DIFF
--- a/audiobook.html
+++ b/audiobook.html
@@ -449,6 +449,21 @@
         color: #24262b;
         background-color: #ffffff;
       }
+      /* Style for Back to Top Button */
+      #backToTopBtn {
+        position: fixed;
+        bottom: 50px;
+        right: 30px;
+        font-size: 45px;
+        background-color: #deb6a8; /* Dark gray */
+        color: white;
+        padding: 5px 15px 0px 15px;
+        border-radius: 40px;
+        cursor: pointer;
+      }
+      #backToTopBtn:hover {
+        background-color: #333; /* Darker gray */
+      }
 
       @media (max-width: 900px) {
         .row {
@@ -746,6 +761,27 @@
           </button>
         </div>
       </div>
+      <button id="backToTopBtn" title="Go to top">^</button>
+      <script>
+          // Get the button element
+          let backToTopBtn = document.getElementById("backToTopBtn");
+          // Show the button when the user scrolls down 20px from the top of the document
+          window.onscroll = function() {
+            scrollFunction();
+          };
+          function scrollFunction() {
+            if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
+              backToTopBtn.style.display = "block";
+            } else {
+              backToTopBtn.style.display = "none";
+            }
+          }
+          // Scroll to the top of the document when the button is clicked
+          backToTopBtn.onclick = function() {
+            document.body.scrollTop = 0; // For Safari
+            document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE, and Opera
+          };
+      </script>
     </section>
     <footer class="footer">
       <div class="container">


### PR DESCRIPTION
#3859 : Add Back to Top button on Audio Book page

That pull request is address the problem of **Back to Top button on Audio Book page**

Fixes:  #3859 

# Description

Before adding Back to top button we have to scroll up manually for going bottom to top

**Before adding Back to top button**
![image](https://github.com/user-attachments/assets/50d98a79-f2a8-45f3-a693-c10fcc79f8bb)

**After adding Back to top button**
![image](https://github.com/user-attachments/assets/ecf22889-5a66-4916-b838-c2428bcfe151)

Issue fixed
#3859 

# Type of PR

- [x] Feature enhancement

# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

