### PR TITLE
Added hover on both Right-arrow and Left-arrow successfully

### DIFF
--- a/assets/css/litrary_realms.css
+++ b/assets/css/litrary_realms.css
@@ -41,7 +41,6 @@
   transition: transform 0.5s ease;
   width: 100%;
   margin: 0;
-  
   padding: 0;
   gap: 20px; /* Gap between cards */
   overflow: hidden; /* Hide extra cards outside of the view */
@@ -77,8 +76,19 @@
   position: absolute;
   right: -60px;
   z-index: 10;
+  transition: color 0.3s ease; /* Smooth transition for color change */
 }
 
+#right-arrow:hover,
+#left-arrow:hover { 
+  color: hsl(357, 79%, 72%); /* Change the color on hover */
+}
+
+/* Dark mode hover styles */
+.dark-mode #right-arrow:hover,
+.dark-mode #left-arrow:hover {
+  color: hsl(357, 79%, 72%); /* Change the color on hover */
+}
 
 .litrealms_card {
   flex: 0 0 calc((100% / 3) - 20px); 
@@ -170,7 +180,7 @@
 /* Dark mode styles for lit realms */
 .dark-mode #right-arrow,
 .dark-mode #left-arrow {
-  background-color: rgb(45, 45, 46);
+  background-color: rgb(46, 45, 45);
 }
 
 .dark-mode #right-arrow::before,

--- a/index.html
+++ b/index.html
@@ -3560,7 +3560,11 @@ body > .skiptranslate {
           </h1>
  
           <div class="carousell-wrapper">
-            <i id="left-arrow" class="fa-solid fa-angle-left"></i>
+            
+            <i id="left-arrow" class="fa-solid fa-angle-left" 
+   style="position: absolute; right: -60px; z-index: 10; color: #dc0d0d; transition: color 0.3s, transform 0.3s; cursor: pointer;" 
+   onmouseover="this.style.color='red'; this.style.transform='scale(1.1)';" 
+   onmouseout="this.style.color='red'; this.style.transform='scale(1)';"></i>
             
             <div class="carousell">
               <div class="litrealms_card">
@@ -3646,7 +3650,12 @@ body > .skiptranslate {
               </div>
             </div>
             
-            <i id="right-arrow" class="fa-solid fa-angle-right"></i>
+            <i id="right-arrow" class="fa-solid fa-angle-right" 
+   style="position: absolute; right: -60px; z-index: 10; color: #dc0d0d; transition: color 0.3s, transform 0.3s; cursor: pointer;" 
+   onmouseover="this.style.color='red'; this.style.transform='scale(1.1)';" 
+   onmouseout="this.style.color='red'; this.style.transform='scale(1)';"></i>
+
+
           </div>
         </div>
       </section>


### PR DESCRIPTION

# Description

Added hover effects to both the #right-arrow and #left-arrow in the carousel component.
On hover, the color of the arrows changes to hsl(357, 79%, 72%), enhancing visual feedback for user interaction.

<!---give the issue number you fixed----->

# 3943

- [ X] Bug fix
- [ X] Feature enhancement
- [X ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)

https://github.com/user-attachments/assets/77f02cdb-8960-4e14-acf0-fbb21d62b635



- [X ] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X  I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

