### PR TITLE
Fix Footer Icon Title Alignment for Improved Visual Consistency

### DIFF
--- a/assets/html/about.html
+++ b/assets/html/about.html
@@ -419,7 +419,7 @@
   text-decoration: none;
   color: rgb(83, 74, 74); /* Adjust link color as needed */
   display: flex;
-  align-items: center;
+  align-items: baseline;
 }
 
 #quicklinks .foot-quick a i {


### PR DESCRIPTION
# Related Issue
Fixes:  #3963 

# Description
This PR addresses the issue of misaligned icon titles in the footer's "Quick Links" section. The text next to the icons was not properly aligned, creating an inconsistent and less visually appealing layout.

<!---give the issue number you fixed----->

# Type of PR

- [X] Bug fix


# Screenshots / videos (if applicable)
- Before
![image](https://github.com/user-attachments/assets/8c7a4eae-a6de-4d2f-a75c-3db73c5fc03b)
- After
![image](https://github.com/user-attachments/assets/982ba234-2adc-4437-b073-c40c2b49d245)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

