### PR TITLE
play button text visible on hovering

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1034,7 +1034,9 @@ body.dark-mode .dropdown-menu-item:hover {
     rgba(0, 0, 0, 0.22) 0px 10px 10px;
 
 }
-
+.play-btn:hover h2 {
+  color: black; /* Change text color to black on hover for better visibility */
+}
 play-btn ion-icon {
   font-size: 24px;
 }


### PR DESCRIPTION
# Related Issue

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

Fixes:  #3840 

# Description

Earlier while hovering on play now button, text was not visible which is not fixed and visible better both in light and dark mode.

<!---give the issue number you fixed----->

# Type of PR

- [X] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
<img width="228" alt="Screenshot 2024-10-25 at 2 35 22 PM" src="https://github.com/user-attachments/assets/f975ab1e-02d8-4932-a1ff-87314772a115">


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

