### PR TITLE
Donate dark mode -> card description visible

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1034,7 +1034,9 @@ body.dark-mode .dropdown-menu-item:hover {
     rgba(0, 0, 0, 0.22) 0px 10px 10px;
 
 }
-
+.play-btn:hover h2 {
+  color: black; /* Change text color to black on hover for better visibility */
+}
 play-btn ion-icon {
   font-size: 24px;
 }

--- a/assets/html/event.html
+++ b/assets/html/event.html
@@ -332,7 +332,7 @@
         <nav>
             <ul class="navbar-list">
                 <li class="navbar-item">
-                  <a href="index.html" class="navbar-link">
+                  <a href="../../index.html" class="navbar-link">
                     <lord-icon
                       src="https://cdn.lordicon.com/qeltvbrs.json"
                       trigger="hover"
@@ -341,7 +341,7 @@
                     </lord-icon>Home</a>
                 </li>
                 <li class="navbar-item">
-                  <a href="books.html" class="navbar-link">
+                  <a href="../../books.html" class="navbar-link">
                     <lord-icon
                       src="https://cdn.lordicon.com/bhmovrlt.json"
                       trigger="hover"
@@ -351,7 +351,7 @@
                     </lord-icon>Books</a>
                 </li>
                 <li class="navbar-item">
-                  <a href="./index.html#genre" class="navbar-link">
+                  <a href="../.././index.html#genre" class="navbar-link">
                     <script src="https://cdn.lordicon.com/lordicon.js"></script>
                     <lord-icon
                       src="https://cdn.lordicon.com/lcvlsnre.json"
@@ -361,7 +361,7 @@
                     </lord-icon>Genres</a>
                 </li>
                 <li class="navbar-item">
-                  <a href="./assets/html/about.html" class="navbar-link">
+                  <a href="../.././assets/html/about.html" class="navbar-link">
                     <lord-icon
                       src="https://cdn.lordicon.com/fozsorqm.json"
                       trigger="hover"

--- a/index.html
+++ b/index.html
@@ -148,7 +148,9 @@
 }
 
 
-
+  .dark-mode .card-text-donate{
+    color: #6c2121;
+  }
 
     /* Position the toggle button to the right */
     .switch-container {


### PR DESCRIPTION
# Related Issue

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

Fixes: #3989 

# Description
Card description was not visible earlier in dark mode of donate books section. now its visible.
[Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.]

<!---give the issue number you fixed----->

# Type of PR

- [X] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
<img width="1440" alt="Screenshot 2024-10-25 at 3 57 16 PM" src="https://github.com/user-attachments/assets/528a4a16-a3ae-41dd-8c91-5fc33ce7eef4">

# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

