### PR TITLE
added hacktoberfest and gssoc banner to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@
 
 <hr>
 
+  ### This project is now OFFICIALLY accepted for
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/alo7lika/Research-Nexas/refs/heads/main/Image/329829127-e79eb6de-81b1-4ffb-b6ed-f018bb977e88.png" alt="GSSoC 2024 Extd" width="80%">
+</div>
+
+<div align="center">
+  <img src="https://raw.githubusercontent.com/alo7lika/Research-Nexas/refs/heads/main/Image/hacktober.png" alt="Hacktober fest 2024" width="80%">
+</div>
+
+<br>  
+
+
 ## Project Structure
 
 <!-- START_STRUCTURE -->


### PR DESCRIPTION

Fixes:  #4046 

# Description

added hacktoberfest and gssoc banner to the readme file.


# Screenshots / videos (if applicable)
<img width="692" alt="Screenshot 2024-10-26 202702" src="https://github.com/user-attachments/assets/ceb7a221-c600-4a60-8b83-f1b838897062">


# Checklist:

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

