### PR TITLE
Removed img tage from README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,9 +694,7 @@ https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
 
 https://github.com/user-attachments/assets/f430e59e-d744-4b60-9884-b7eb4643ba72
 
-<img src="./home.png" />
-<img src="./benefits.png" />
-<img src="./genre.png" />
+
 
 🌐 **Visit our website:** [SwapReads](https://swapreadsconnect.netlify.app/#)
 


### PR DESCRIPTION
Removed the shown logo because no image was available in repo

![Screenshot (746)](https://github.com/user-attachments/assets/54fa9766-5902-488e-ab3d-73296fad7bac)
