### PR TITLE
Modified the blinking cursor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1421,7 +1421,7 @@
     <div class="progress-bar" id="progress-bar"></div>
   </div>
 
-  
+
 
   <script src="script.js"></script>
 
@@ -3767,6 +3767,9 @@
                     setTimeout(typing, 100);
                   } else {
                     h1Typing.classList.add('blinking-cursor');
+                    setTimeout(() => {
+                      h1Typing.classList.remove('blinking-cursor');
+                    }, 2000); //Timeout the cursor after 2 seconds
                   }
                 }
                 typing();


### PR DESCRIPTION
# Related Issue
Cursor kept on blinking , even after writing the complete heading

Fixes:  #4065 

# Description

Earlier the cursor kept on blinking even after writing the sentence completely. It was not appealing to the eyes and was not looking professional. So I set a timeout function which stops the blinking of cursor after 2 seconds after the completion of sentence.

<!---4065----->

# Type of PR

- [x] Bug fix
- [x] Feature enhancement

# Screenshots / videos (if applicable)
**Before**

https://github.com/user-attachments/assets/bc4f685c-b9d1-47d2-921c-a4230ab1e2ba

**After**

https://github.com/user-attachments/assets/56659e12-4b9a-4c00-9747-7a37cf7e0aaf



# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

