### PR TITLE
🛠️FIX : Add Genre Dropdown for Improved User Experience

### DIFF
--- a/assets/html/booklistswap.html
+++ b/assets/html/booklistswap.html
@@ -328,6 +328,20 @@
       box-sizing: border-box;
     }
 
+    select{
+      width: 100%;
+      padding: 10px;
+      margin: 10px 0;
+      border: 1px solid var(--light-gray);
+      border-radius: 3px;
+      box-sizing: border-box;
+    }
+
+    select option{
+      font-size: 15px;
+      
+    }
+    
     h2 {
       color: var(--charcoal);
       font-size: 20px;
@@ -867,7 +881,35 @@
       <form id="book-form">
         <input type="text" id="book-title" placeholder="Book Title" required>
         <input type="text" id="book-author" placeholder="Author" required>
-        <input type="text" id="book-genre" placeholder="Genre" required>
+        <select id="book-genre" required>
+          <option value="" disabled selected>Genre</option>
+            <option value="classical literature">Classical Literature</option>
+            <option value="romance">Romance</option>
+            <option value="suspense thriller">Suspense Thriller</option>
+            <option value="science fiction">Science Fiction</option>
+            <option value="fantasy">Fantasy</option>
+            <option value="horror">Horror</option>
+            <option value="historical fiction">Historical Fiction</option>
+            <option value="adventure">Adventure</option>
+            <option value="comedy">Comedy</option>
+            <option value="detective fiction">Detective Fiction</option>
+            <option value="fairy tales">Fairy Tales</option>
+            <option value="mythology">Mythology</option>
+            <option value="noir">Noir</option>
+            <option value="dystopian">Dystopian</option>
+            <option value="magical realism">Magical Realism</option>
+            <option value="cyber punk">Cyber Punk</option>
+            <option value="utopian">Utopian</option>
+            <option value="satire">Satire</option>
+            <option value="psychological thriller">Psychological Thriller</option>
+            <option value="biography">Biography</option>
+            <option value="self help">Self Help</option>
+            <option value="non fiction">Non Fiction</option>
+            <option value="philosophy">Philosophy</option>
+            <option value="poetry">Poetry</option>
+            <option value="true crime">True Crime</option>
+            <option value="autobiography">Autobiography</option>
+        </select>
         <button type="submit" id="a">Add to List</button>
       </form>
       <h2>Ready-to-Swap Reads</h2>


### PR DESCRIPTION
# Related Issue

“None”

# Fixes:  #4103 
# Description

Currently, the genre input field does not require users to manually enter their preferred genre on the swap book page. To enhance the user experience and reduce errors, we added a dropdown menu with predefined genre options.



# Type of PR


- [x] Feature enhancement


# Screenshots 
![image](https://github.com/user-attachments/assets/e890e244-084b-43de-bb01-1c5aac5b7b06)


# Checklist:



- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

