### PR TITLE
add buttons for navigating through different genre of books

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@
 ├── privacynotice.html
 ├── profile.css
 ├── profile.html
+├── refundpolicy.html
 ├── repo_structure.txt
 ├── revitalize.html
 ├── romantic-esc.html

--- a/assets/css/playNow.css
+++ b/assets/css/playNow.css
@@ -561,6 +561,55 @@ footer {
   overflow: hidden;
 }
 
+/* Central container for navigation buttons */
+.genre-nav {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 20px 0;
+}
+
+/* Button style in light mode */
+.genre-nav button {
+  padding: 10px 15px;
+  border: none;
+  border-radius: 5px;
+  font-size: 1rem;
+  font-weight: 600; /* Increased font weight */
+  cursor: pointer;
+  background-color: rgb(230, 103, 124); /* Light mode background color */
+  color: rgba(255, 255, 255, 0.909); /* Light mode text color */
+  transition: background-color 0.3s, transform 0.3s; /* Smooth transition */
+}
+
+/* Hover animation for buttons in light mode */
+.genre-nav button:hover {
+  background-color: rgb(200, 85, 110); /* Slightly darker shade on hover */
+  transform: scale(1.05); /* Slight zoom-in effect */
+}
+
+/* Dark mode button style */
+body.dark-mode .genre-nav button {
+  background-color: rgb(88, 22, 33); /* Dark mode background color */
+  color: rgba(255, 255, 255, 0.909); /* Dark mode text color */
+}
+
+/* Hover animation for buttons in dark mode */
+body.dark-mode .genre-nav button:hover {
+  background-color: rgb(66, 15, 25); /* Slightly darker shade on hover */
+  transform: scale(1.05); /* Slight zoom-in effect */
+}
+
+/* Responsive styling */
+@media (max-width: 600px) {
+  .genre-nav button {
+    width: 100%;
+    text-align: center;
+    margin-bottom: 10px;
+  }
+}
+
 /*responsiveness*/
 /* Responsive adjustments for medium screens (tablets) */
 @media (max-width: 992px) {

--- a/playNow.html
+++ b/playNow.html
@@ -329,7 +329,6 @@ body {
 .section-title {
   font-family: 'Merriweather', serif;
   font-size: 1.5rem;
-  color: #c21807; /* Dark pink or any accent color */
   font-weight: 700;
   text-align: center;
   display: flex;
@@ -337,6 +336,12 @@ body {
   justify-content: center;
   margin: 30px 0; /* Add spacing above and below */
   gap: 15px; /* Space between the line and text */
+  color: rgb(230, 103, 124); 
+  background-color:  rgba( 255, 255, 255, 0.909 );
+  padding: 10px;
+  border-radius: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  text-align: center;
 }
 
 input, button, textarea {
@@ -703,6 +708,13 @@ input, button, textarea {
 
                 // Start the animation
                 animateCircles();
+
+                function scrollToGenre(genreId) {
+                  const element = document.getElementById(genreId);
+                  if (element) {
+                    element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                  }
+                }
                   </script>
                   </header>
 
@@ -710,9 +722,20 @@ input, button, textarea {
     <span>Explore Books Popular Among SwapRead Users in Different Genres</span>
     </div>
                   
+    <div class="genre-nav">
+      <button onclick="scrollToGenre('romance')">Romance</button>
+      <button onclick="scrollToGenre('sci-fi')">Science Fiction</button>
+      <button onclick="scrollToGenre('mystery')">Mystery</button>
+      <button onclick="scrollToGenre('fantasy')">Fantasy</button>
+      <button onclick="scrollToGenre('thriller')">Thriller</button>
+      <button onclick="scrollToGenre('comedy')">Comedy</button>
+      <button onclick="scrollToGenre('true-crime')">True Crime</button>
+      <button onclick="scrollToGenre('philosophy')">Philosophy</button>
+    </div>
+
     <div class="container">
       <!-- Romance Genre Section -->
-      <div class="genre-section">
+      <div class="genre-section" id="romance">
         <div class="hero-banner has-before">
           <img
             src="./assets/images/rom.jpg"
@@ -740,7 +763,7 @@ input, button, textarea {
       </div>
 
       <!-- Science Fiction Genre Section -->
-      <div class="genre-section">
+      <div class="genre-section" id="sci-fi">
         <div class="genre-content">
           <h2 class="genre-title">Neuromancer Trilogy </h2>
           <span style="font-size:5rem;filter: grayscale(100%);float: right;">🚀</span>
@@ -766,7 +789,7 @@ input, button, textarea {
       </div>
 
       <!-- Mystery Genre Section -->
-      <div class="genre-section">
+      <div class="genre-section" id="mystery">
         <div class="hero-banner has-before">
           <img
             src="./assets/images/mystery.jpg"
@@ -793,7 +816,7 @@ input, button, textarea {
       </div>
 
       <!-- Fantasy Genre Section -->
-      <div class="genre-section">
+      <div class="genre-section" id="fantasy">
         <div class="genre-content">
           <h2 class="genre-title">A Court of Thorns and Roses</h2>
           <span style="font-size:5rem;filter: grayscale(100%); float: right;">🔮</span>
@@ -820,7 +843,7 @@ input, button, textarea {
       </div>
 
       <!-- Thriller Genre Section -->
-      <div class="genre-section">
+      <div class="genre-section" id="thriller">
         <div class="hero-banner has-before">
           <img
             src="./assets/images/thriller.jpg"
@@ -847,7 +870,7 @@ input, button, textarea {
       </div>
 
       <!-- Comedy Genre Section -->
-      <div class="genre-section">
+      <div class="genre-section" id="comedy">
         <div class="genre-content">
           <h2 class="genre-title">Carry On, Jeeves</h2>
           <span style="font-size:5rem;filter: grayscale(100%); float: right;">🤹</span>
@@ -872,7 +895,7 @@ input, button, textarea {
       </div>
 
       <!-- True Crime Genre Section -->
-      <div class="genre-section">
+      <div class="genre-section" id="true-crime">
         <div class="hero-banner has-before">
           <img
             src="./assets/images/true crime.jpg"
@@ -897,7 +920,7 @@ input, button, textarea {
       </div>
 
       <!-- Philosophy Genre Section -->
-      <div class="genre-section">
+      <div class="genre-section" id="philosophy">
         <div class="genre-content">
           <h2 class="genre-title">Meditations</h2>
           <span style="font-size:5rem;filter: grayscale(100%); float: right;">📜</span>

--- a/repo_structure.txt
+++ b/repo_structure.txt
@@ -382,6 +382,7 @@
 ├── privacynotice.html
 ├── profile.css
 ├── profile.html
+├── refundpolicy.html
 ├── repo_structure.txt
 ├── revitalize.html
 ├── romantic-esc.html


### PR DESCRIPTION
# Related Issue
None

Fixes:  #4135

# Description
Added stylized buttons and improved the sub-heading of playNow page (accessible from play now button on home pg). These buttons allows users to scroll to books of a specific genre easier making navigation easier and improving user experience. The buttons looks good in both light and dark mode.

# Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
Before:
![image](https://github.com/user-attachments/assets/fad092fb-a429-40a1-b245-8cc5c8cc2bbf)

After:
https://github.com/user-attachments/assets/7e7b58aa-88e7-493a-a47f-de40f0d0a02b

# Checklist:
- [X] I have made this change from my own.
- [X] I have taken help from some online resources.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

