### PR TITLE
🛠️ FIX : Display Last Login Time on Profile Page

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -539,7 +539,47 @@ a {
                 <h1 class="profile-name">John Doe</h1>
                 <p class="profile-email"><i class="fas fa-envelope"></i> email@example.com</p>
                 <p class="profile-phone"><i class="fas fa-phone"></i> +123 456 7890</p>
-                <p class="profile-last-login" id="last-login-time">Last login: Not available</p>
+                <!-- <p class="profile-last-login" id="last-active">Last login:<p> -->
+                  <p id="last-active"></p>
+
+<script>
+
+// Get current timestamp
+const getCurrentTimestamp = () => {
+  return new Date().getTime();
+};
+
+// Store last active timestamp in LocalStorage
+const storeLastActive = () => {
+  const lastActive = getCurrentTimestamp();
+  localStorage.setItem('lastActive', lastActive);
+};
+
+// Get last active timestamp from LocalStorage
+const getLastActive = () => {
+  return localStorage.getItem('lastActive');
+};
+
+// Update last active timestamp on page load and interaction
+document.addEventListener('DOMContentLoaded', storeLastActive);
+document.addEventListener('click', storeLastActive);
+document.addEventListener('scroll', storeLastActive);
+document.addEventListener('keydown', storeLastActive);
+
+// Example usage:
+const displayLastActive = () => {
+  const lastActive = getLastActive();
+  const formattedTime = new Date(parseInt(lastActive)).toLocaleString();
+  document.getElementById('last-active').innerHTML = `Last active: ${formattedTime}`;
+};
+
+displayLastActive();
+
+
+</script>
+
+
+
                 <a href="./assets/html/profileedit.html">
                     <button class="edit-profile-btn">
                       <i class="fas fa-edit"></i> 
@@ -879,7 +919,7 @@ a {
             });
             localStorage.setItem("wishlistItems", JSON.stringify(wishlistItems));
         }
-    </script>
+    </>
     <script>
         // Coordinates for the cursor
         const coords = { x: 0, y: 0 };


### PR DESCRIPTION

# Related Issue

“None”

Fixes:  #4155

# Description

The profile page displays the user's last login time.


# Type of PR

- [x] Bug fix
- [x] Feature enhancement

# Screenshots 

## Before 
![image](https://github.com/user-attachments/assets/60740462-9eb0-44f1-99b3-86689633e97b)

## After
![image](https://github.com/user-attachments/assets/ea2a3bf9-8575-4406-8fed-8c802e6dec6e)

# Checklist:


- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

