### PR TITLE
Add fantasy science-fiction books

### DIFF
--- a/fantasy.html
+++ b/fantasy.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fantasy Books</title>
+    <style>
+      body {
+        margin: 0;
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        background-color: #ffb2a8; /* Light lavender background */
+        overflow-y: scroll;
+        scrollbar-width: thin;
+        scrollbar-color: #888 #f1f1f1;
+        cursor: default;
+      }
+
+      body::-webkit-scrollbar {
+        width: 12px;
+      }
+
+      body::-webkit-scrollbar-track {
+        background: #f1f1f1;
+      }
+
+      body::-webkit-scrollbar-thumb {
+        background-color: #888;
+        border-radius: 6px;
+        border: 3px solid #f1f1f1;
+      }
+
+      body::-webkit-scrollbar-thumb:hover {
+        background-color: #555;
+      }
+
+      .card-container {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+
+      .book-card {
+        background-color: #fff;
+        border-radius: 8px;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        margin: 15px;
+        padding: 20px;
+        width: 250px;
+        transition: transform 0.3s;
+      }
+
+      .book-card:hover {
+        transform: translateY(-5px);
+      }
+
+      .book-title {
+        font-size: 18px;
+        font-weight: bold;
+        margin-bottom: 10px;
+        color: #333;
+      }
+
+      .book-author {
+        font-size: 14px;
+        color: #777;
+        margin-bottom: 15px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Fantasy Books</h1>
+    <div class="card-container" id="bookCards">
+      <!-- Hardcoded book cards for Fantasy genre -->
+      <div class="book-card">
+        <p class="book-title">The Hobbit</p>
+        <p class="book-author">by J.R.R. Tolkien</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Harry Potter and the Sorcerer's Stone</p>
+        <p class="book-author">by J.K. Rowling</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">A Game of Thrones</p>
+        <p class="book-author">by George R.R. Martin</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Name of the Wind</p>
+        <p class="book-author">by Patrick Rothfuss</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Way of Kings</p>
+        <p class="book-author">by Brandon Sanderson</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Mistborn: The Final Empire</p>
+        <p class="book-author">by Brandon Sanderson</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Good Omens</p>
+        <p class="book-author">by Neil Gaiman & Terry Pratchett</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Eye of the World</p>
+        <p class="book-author">by Robert Jordan</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Lies of Locke Lamora</p>
+        <p class="book-author">by Scott Lynch</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Eragon</p>
+        <p class="book-author">by Christopher Paolini</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Priory of the Orange Tree</p>
+        <p class="book-author">by Samantha Shannon</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Once and Future King</p>
+        <p class="book-author">by T.H. White</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Witcher: The Last Wish</p>
+        <p class="book-author">by Andrzej Sapkowski</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">American Gods</p>
+        <p class="book-author">by Neil Gaiman</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Uprooted</p>
+        <p class="book-author">by Naomi Novik</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Stardust</p>
+        <p class="book-author">by Neil Gaiman</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Blade Itself</p>
+        <p class="book-author">by Joe Abercrombie</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">His Dark Materials: The Golden Compass</p>
+        <p class="book-author">by Philip Pullman</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Poppy War</p>
+        <p class="book-author">by R.F. Kuang</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Black Prism</p>
+        <p class="book-author">by Brent Weeks</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4705,6 +4705,7 @@
               </li>
 
               <li data-aos="slide-right">
+                <a href="science-fiction.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">04</p>
@@ -4729,9 +4730,11 @@
                   </ul>
 
                 </div>
+                </a>
               </li>
 
               <li data-aos="zoom-in">
+                <a href="fantasy.html" style="text-decoration: none; color: inherit;"></a>
                 <div class="chapter-card">
 
                   <p class="card-subtitle">05</p>
@@ -4755,6 +4758,7 @@
                   </ul>
 
                 </div>
+                </a>
               </li>
 
               <li data-aos="slide-left">

--- a/index.html
+++ b/index.html
@@ -4734,7 +4734,7 @@
               </li>
 
               <li data-aos="zoom-in">
-                <a href="fantasy.html" style="text-decoration: none; color: inherit;"></a>
+                <a href="fantasy.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">05</p>

--- a/science-fiction.html
+++ b/science-fiction.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Science Fiction Books</title>
+    <style>
+      body {
+        margin: 0;
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        background-color: #ffb2a8; /* Light blue background */
+        overflow-y: scroll;
+        scrollbar-width: thin;
+        scrollbar-color: #888 #f1f1f1;
+        cursor: default;
+      }
+
+      body::-webkit-scrollbar {
+        width: 12px;
+      }
+
+      body::-webkit-scrollbar-track {
+        background: #f1f1f1;
+      }
+
+      body::-webkit-scrollbar-thumb {
+        background-color: #888;
+        border-radius: 6px;
+        border: 3px solid #f1f1f1;
+      }
+
+      body::-webkit-scrollbar-thumb:hover {
+        background-color: #555;
+      }
+
+      .card-container {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+
+      .book-card {
+        background-color: #fff;
+        border-radius: 8px;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        margin: 15px;
+        padding: 20px;
+        width: 250px;
+        transition: transform 0.3s;
+      }
+
+      .book-card:hover {
+        transform: translateY(-5px);
+      }
+
+      .book-title {
+        font-size: 18px;
+        font-weight: bold;
+        margin-bottom: 10px;
+        color: #333;
+      }
+
+      .book-author {
+        font-size: 14px;
+        color: #777;
+        margin-bottom: 15px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Science Fiction Books</h1>
+    <div class="card-container" id="bookCards">
+      <!-- Hardcoded book cards for Science Fiction genre -->
+      <div class="book-card">
+        <p class="book-title">Dune</p>
+        <p class="book-author">by Frank Herbert</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Neuromancer</p>
+        <p class="book-author">by William Gibson</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Snow Crash</p>
+        <p class="book-author">by Neal Stephenson</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Left Hand of Darkness</p>
+        <p class="book-author">by Ursula K. Le Guin</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Foundation</p>
+        <p class="book-author">by Isaac Asimov</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Hyperion</p>
+        <p class="book-author">by Dan Simmons</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Expanse: Leviathan Wakes</p>
+        <p class="book-author">by James S.A. Corey</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Kindred</p>
+        <p class="book-author">by Octavia E. Butler</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Time Machine</p>
+        <p class="book-author">by H.G. Wells</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Ender's Game</p>
+        <p class="book-author">by Orson Scott Card</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The War of the Worlds</p>
+        <p class="book-author">by H.G. Wells</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Three-Body Problem</p>
+        <p class="book-author">by Liu Cixin</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Altered Carbon</p>
+        <p class="book-author">by Richard K. Morgan</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Brave New World</p>
+        <p class="book-author">by Aldous Huxley</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Martian</p>
+        <p class="book-author">by Andy Weir</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Do Androids Dream of Electric Sheep?</p>
+        <p class="book-author">by Philip K. Dick</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">The Stars My Destination</p>
+        <p class="book-author">by Alfred Bester</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Fahrenheit 451</p>
+        <p class="book-author">by Ray Bradbury</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Children of Time</p>
+        <p class="book-author">by Adrian Tchaikovsky</p>
+      </div>
+      <div class="book-card">
+        <p class="book-title">Red Mars</p>
+        <p class="book-author">by Kim Stanley Robinson</p>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
# Related Issue

## fixes #4201



# Description

THIS pr adds pages science-fiction.html and fantasy.html  to display books of the genres.

issue #4201 
# Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
![Screenshot 2024-10-29 003254](https://github.com/user-attachments/assets/cc460c37-1e0a-45c5-a1bb-cf883ace24a2)
![Screenshot 2024-10-29 003318](https://github.com/user-attachments/assets/824cae64-db0f-473e-83d2-586bd3cc1374)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [X] I have made this change from my own.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers and screenshots after making the changes.

