### PR TITLE
removed default cursor

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
       overflow-y: scroll;
       scrollbar-width: thin;
       scrollbar-color: #888 #f1f1f1;
-      cursor: default;
+      cursor: none !important;
       /* Show default cursor */
     }
 


### PR DESCRIPTION
Fixes:  #4233 

# Description

As the website uses a custom cursor then there is no need of a default cursor which will improve overall look

# Type of PR

- [x] Bug fix
- [x] Feature enhancement

# Screenshots / videos (if applicable)

before:
[ice_video_20241029-222212.webm](https://github.com/user-attachments/assets/92cf1985-d8e6-4c96-a104-25b68c2b0f69)
has black default cursor

after:
[ice_video_20241029-223530.webm](https://github.com/user-attachments/assets/08b30742-d234-4f68-9b6c-480933ff36a6)

# Checklist:

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

add label hactoberfest and gssoc-ex


