### PR TITLE
added the 'our-vision' link on footer of certain pages 

### DIFF
--- a/assets/html/booklistswap.html
+++ b/assets/html/booklistswap.html
@@ -1125,7 +1125,7 @@
 
 
       <a href="/copyrightpolicy.html" id="copyrightPolicyLink">Copyright Policy</a> |
-      <a href="/privacynotice.html" id="privacyNoticeLink">Privacy Notice</a>  
+      <a href="/privacynotice.html" id="privacyNoticeLink">Privacy Notice</a> |
       <a href="/our-vision.html">Our Vision</a></li>
     </div>
     </div>

--- a/chat.html
+++ b/chat.html
@@ -746,7 +746,8 @@ window.addEventListener("scroll", onScroll);
 
 
             <a href="copyrightpolicy.html" id="copyrightPolicyLink">Copyright Policy</a> |
-            <a href="privacynotice.html" id="privacyNoticeLink">Privacy Notice</a>
+            <a href="privacynotice.html" id="privacyNoticeLink">Privacy Notice</a> |
+            <a href="our-vision.html">Our Vision</a>
         </div>
     </div>
 


### PR DESCRIPTION
# Related Issue

NONE

# Description

I have added the 'OUR VISION' link on the footer of certain pages which was missing earlier.

# Type of PR

- [ ] Other (specify): added a missing link on footer of pages.

# Screenshots / videos (if applicable)

Before:
![image](https://github.com/user-attachments/assets/f1fdd8f8-04d2-4d21-8382-e2d17f5477cc)

After: 
![image](https://github.com/user-attachments/assets/34eaf9dc-0992-4b92-a1d3-2e54abd06fe3)


# Checklist:

- [x ] I have made this change from my own.
- [x ] My code follows the style guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [x ] I have made corresponding changes to the documentation.
- [ x] My changes generate no new warnings.
- [x ] I have tested the changes thoroughly before submitting this pull request.
- [ x] I have provided relevant issue numbers and screenshots after making the changes.

