### PR TITLE
🛠️FIX : About Us pages' stats counting

### DIFF
--- a/assets/html/about.html
+++ b/assets/html/about.html
@@ -2074,6 +2074,36 @@ body > .skiptranslate {
   }
 
   fetchContributors();
+
+
+ // Function to animate counting from 0 to a target number
+ function countUp(target, elementId) {
+              let count = 0;
+              const increment = target / 150; // Increment by a fraction of the target number
+    
+              const interval = setInterval(() => {
+                count += increment;
+                document.getElementById(elementId).textContent = Math.round(count) + "+"; // Add the "+" sign
+    
+                // Stop the interval when count reaches or exceeds the target number
+                if (count >= target) {
+                  clearInterval(interval);
+                  document.getElementById(elementId).textContent = target + "+"; // Ensure final value is exact with the "+"
+                  // Start counting animation again after a delay
+                  setTimeout(() => {
+                    countUp(target, elementId);
+                  }, 4000); 
+                }
+              }, 20); 
+            }
+    
+            // Start counting animation for each stat
+            countUp(2500, 'stat1'); 
+            countUp(100, 'stat2'); 
+            countUp(5000, 'stat3'); 
+
+
+  
 </script>
 
 </body>


### PR DESCRIPTION


# Related Issue

 “None”

Fixes:  #4469

# Description
About Us pages' stats are now working. It's showing counting numberrs .


# Type of PR

- [x] Bug fix
- [x] Feature enhancement


# Screenshots / videos (if applicable)

https://github.com/user-attachments/assets/cd7bcaf9-4495-468f-97c0-f24f32e8d3ad



# Checklist:



- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

