### PR TITLE
Fixed homepage visitor counter to track unique visits only once per user session

### DIFF
--- a/assets/js/visitors.js
+++ b/assets/js/visitors.js
@@ -5,9 +5,14 @@
   
   // Function to increment and save the count
   function incrementVisitorCount() {
-    let count = parseInt(getVisitorCount()) + 1;
-    localStorage.setItem('visitorCount', count);
-    return count;
+    if (!localStorage.getItem('visitedHomePage')) {
+      let count = parseInt(getVisitorCount()) + 1;
+      localStorage.setItem('visitorCount', count);
+      localStorage.setItem('visitedHomePage', 'true');
+      return count;
+    }
+    
+    return getVisitorCount();
   }
   
   // Function to display the count


### PR DESCRIPTION
#PR: Fixed homepage visitor counter to track unique visits only once per user session

Fix #4486 

## Description
This PR addresses the issue where the visitor count increments each time a user returns to the homepage, even if they have already been counted. The visitor count now only increments on the first visit per user session, ensuring each visitor is counted only once.

## Changes Made
- Added a check using `localStorage` to track if a user has already visited the homepage.
- If the `visitedHomePage` flag is not set, the visitor count is incremented, and the flag is set in `localStorage`.
- Subsequent visits in the same session do not increment the counter, preserving the unique count.

## Testing
- Verified that the visitor count increments only once per session.
- Tested multiple navigations back to the homepage; count remains stable after the initial increment.

This update ensures accurate visitor tracking by counting each user only once per session.

@anuragverma108
Pls assign this, give me labels, level.