### PR TITLE
adding buttons in genre section of home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@
 │   │   │       └── event.css
 │   │   ├── audio.html
 │   │   ├── author.html
+│   │   ├── biography.html
 │   │   ├── blog.html
 │   │   ├── book_recommend.html
 │   │   ├── booking.html
@@ -174,6 +175,7 @@
 │   │   ├── freeBooks.html
 │   │   ├── god.html
 │   │   ├── googlece7a206a6cfbb7ed.html
+│   │   ├── historical-fiction.html
 │   │   ├── horror.html
 │   │   ├── image.png
 │   │   ├── img.png
@@ -194,15 +196,19 @@
 │   │   ├── romance.html
 │   │   ├── school.html
 │   │   ├── science-fiction.html
+│   │   ├── self-help.html
 │   │   ├── social.html
 │   │   ├── suspense-thriller.html
 │   │   ├── tips.html
 │   │   └── top10.html
 │   ├── images/
+│   │   ├── 1984.jpg
 │   │   ├── FB icon.png
 │   │   ├── LogoPicDark.png
 │   │   ├── LogoPicLight.png
+│   │   ├── Madame Bovary.webp
 │   │   ├── Screenshot 2024-10-28 at 12.09.51 AM
+│   │   ├── The Picture of Dorian Gray.jpg
 │   │   ├── TheGuide.jpg
 │   │   ├── Wings_of_Fire_by_A_P_J_Abdul_Kalam_Book_Cover.jpg
 │   │   ├── YT icon.png
@@ -212,6 +218,9 @@
 │   │   ├── achievement-3.jpg
 │   │   ├── achievement-4.jpg
 │   │   ├── achievement-5.jpg
+│   │   ├── alter.jpeg
+│   │   ├── american.jpg
+│   │   ├── anna_karenina.jpg
 │   │   ├── author-banner.png
 │   │   ├── avatar1.jpg
 │   │   ├── avatar2.jpg
@@ -220,12 +229,17 @@
 │   │   ├── avatar5.jpg
 │   │   ├── award.svg
 │   │   ├── be.jpeg
+│   │   ├── beach.jpg
+│   │   ├── bear.jpg
+│   │   ├── before.jpg
+│   │   ├── behind.jpg
 │   │   ├── benefits-1.svg
 │   │   ├── benefits-2.svg
 │   │   ├── benefits-3.svg
 │   │   ├── benefits-4.svg
 │   │   ├── benefits-5.svg
 │   │   ├── benefits-6.svg
+│   │   ├── big.jpg
 │   │   ├── book/
 │   │   │   ├── Army.jpg
 │   │   │   ├── Economist.jpg
@@ -242,6 +256,11 @@
 │   │   ├── books_swapRead.jpg
 │   │   ├── bookshelf.png
 │   │   ├── bookshelfhover.png
+│   │   ├── brave.jpeg
+│   │   ├── brothers_karamazov.jpg
+│   │   ├── catcher_in_the_rye.jpg
+│   │   ├── chain.jpg
+│   │   ├── city.jpeg
 │   │   ├── cl.jpg
 │   │   ├── close-white.png
 │   │   ├── close.png
@@ -250,12 +269,18 @@
 │   │   ├── community.png
 │   │   ├── communityhover.png
 │   │   ├── contact.png
+│   │   ├── couple.jpg
+│   │   ├── court.jpg
+│   │   ├── crime_and_punishment.jpg
 │   │   ├── ctc1.png
 │   │   ├── ctc2.png
 │   │   ├── ctc3.png
 │   │   ├── ctc4.png
 │   │   ├── ctc5.png
 │   │   ├── darkmode_bg.png
+│   │   ├── dracula.webp
+│   │   ├── duno.jpeg
+│   │   ├── duno.jpg
 │   │   ├── edit profile.jpg
 │   │   ├── em.jpeg
 │   │   ├── emoji/
@@ -264,10 +289,16 @@
 │   │   │   ├── emoji-3.png
 │   │   │   ├── emoji-4.png
 │   │   │   └── emoji-5.png
+│   │   ├── enders.jpg
 │   │   ├── eye-close.png
 │   │   ├── eye-open.png
+│   │   ├── fahrenheit.jpeg
 │   │   ├── fantasy.jpg
+│   │   ├── fates.jpg
 │   │   ├── final.png
+│   │   ├── foundation.jpeg
+│   │   ├── frankenstein.jpg
+│   │   ├── game.jpg
 │   │   ├── genres/
 │   │   │   ├── 1.jpg
 │   │   │   ├── 10.jpg
@@ -283,13 +314,25 @@
 │   │   │   ├── auth2.jpg
 │   │   │   ├── auth3.jpg
 │   │   │   └── c1.jpg
+│   │   ├── girl.jpg
+│   │   ├── gone.jpg
 │   │   ├── good of small tjings.jpg
 │   │   ├── google button.jpeg
 │   │   ├── google icon.jpeg
 │   │   ├── gr.jpeg
+│   │   ├── great-expectations.jpeg
+│   │   ├── great_gatsby.jpg
+│   │   ├── guest.jpg
+│   │   ├── harry.jpg
+│   │   ├── hating.jpg
 │   │   ├── help.png
 │   │   ├── hero-banner.png
 │   │   ├── hero-section.avif
+│   │   ├── hitcher.jpeg
+│   │   ├── hobbit.jpg
+│   │   ├── hola.jpg
+│   │   ├── honey.jpg
+│   │   ├── hype.jpeg
 │   │   ├── icons8-sun.svg
 │   │   ├── images/
 │   │   │   ├── b.jpg
@@ -303,24 +346,43 @@
 │   │   ├── inbox.png
 │   │   ├── india after gandhi.jpg
 │   │   ├── insta icon.png
+│   │   ├── itends.jpg
 │   │   ├── ja.jpeg
+│   │   ├── jane_eyre.jpg
 │   │   ├── jk.jpeg
 │   │   ├── jo.jpeg
+│   │   ├── kiss.jpg
+│   │   ├── left.jpeg
+│   │   ├── les.jpg
+│   │   ├── lock.jpg
 │   │   ├── logo_darkbg.png
 │   │   ├── logo_whitebg.png
 │   │   ├── logout.png
 │   │   ├── ma.jpg
+│   │   ├── martian.jpeg
+│   │   ├── mebeforeyou.jpg
 │   │   ├── mg.jpeg
 │   │   ├── midnight children.jpg
+│   │   ├── mist.jpg
+│   │   ├── moby.jpg
 │   │   ├── moon.png
 │   │   ├── moon_solid.svg
 │   │   ├── mystery.jpg
+│   │   ├── name.jpg
+│   │   ├── narnia.jpg
 │   │   ├── ne.jpeg
 │   │   ├── nes.jpeg
+│   │   ├── neuro.jpeg
 │   │   ├── new_logo.png
 │   │   ├── new_logo_banner_dark.png
 │   │   ├── new_logo_banner_light.png
 │   │   ├── new_logo_dark.png
+│   │   ├── night.jpg
+│   │   ├── notebook.jpeg
+│   │   ├── odyssey.jpg
+│   │   ├── oryx.jpeg
+│   │   ├── oryx.jpg
+│   │   ├── outlander.jpg
 │   │   ├── philopsphy.jpg
 │   │   ├── pic1.jpeg
 │   │   ├── pic2.jpeg
@@ -331,13 +393,22 @@
 │   │   ├── preview-3.png
 │   │   ├── preview-4.png
 │   │   ├── preview-5.png
+│   │   ├── pride.jpg
+│   │   ├── priory.jpg
 │   │   ├── re.jpg
 │   │   ├── read.png
 │   │   ├── readhover.png
+│   │   ├── ready.jpeg
+│   │   ├── red.jpg
 │   │   ├── rom.jpg
+│   │   ├── rosie.jpg
+│   │   ├── scarlet.jpg
 │   │   ├── sci.jpg
 │   │   ├── settings.png
 │   │   ├── shantaram.jpg
+│   │   ├── shutter.jpg
+│   │   ├── silent.jpg
+│   │   ├── snow.jpeg
 │   │   ├── sun.png
 │   │   ├── tele.png
 │   │   ├── telephone.png
@@ -349,6 +420,7 @@
 │   │   ├── testimonials-6.jpg
 │   │   ├── the inheritance of book.jpg
 │   │   ├── thriller.jpg
+│   │   ├── to_kill_a_mockingbird.png
 │   │   ├── train to paki.jpg
 │   │   ├── trendingbook1.jpg
 │   │   ├── trendingbook2.jpg
@@ -358,9 +430,16 @@
 │   │   ├── true crime.jpg
 │   │   ├── twitter-icon.png
 │   │   ├── twitter.png
+│   │   ├── uprooted.jpg
 │   │   ├── user.jpg
+│   │   ├── war.jpeg
 │   │   ├── website-ss.png
-│   │   └── white tiger.jpg
+│   │   ├── wheel.jpg
+│   │   ├── white tiger.jpg
+│   │   ├── wife.jpg
+│   │   ├── wild.jpg
+│   │   ├── woman.jpg
+│   │   └── wuthering_heights.jpg
 │   ├── js/
 │   │   ├── ReaderConn.js
 │   │   ├── addremove.js
@@ -427,10 +506,10 @@
 ├── connectWithsame.html
 ├── contactus1.html
 ├── contributing.txt
-├── contributors/
-│   ├── contributor.css
-│   ├── contributor.html
-│   └── contributor.js
+├── contributor/
+│   ├── contributorss.css
+│   ├── contributorss.html
+│   └── contributorss.js
 ├── controller/
 │   ├── Rating.js
 │   ├── book.js

--- a/index.html
+++ b/index.html
@@ -666,6 +666,79 @@
       }
     }
 
+.cta2.style-9 {
+      position: absolute;
+      bottom: 40px; /* Positions the link 20px above the bottom of the card */
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+  font-size: 1.2rem;
+}
+
+    .cta2 {
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      margin: auto;
+      padding: 2rem 2.4rem;
+      color: hsl(357, 37%, 62%);
+      font-family: Avenir, sans-serif;
+      text-decoration: none;
+      transition: all 0.2s ease;
+
+      &:before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: block;
+        border-radius: 2.8rem;
+        background: rgba(255, 171, 157, 0.5);
+        width: 28rem;
+        height: 5.6rem;
+        transition: all 0.3s ease;
+      }
+
+      span {
+        position: relative;
+        font-size: 0.8rem;
+        line-height: 1.8rem;
+        font-weight: 900;
+        letter-spacing: 0.25em;
+        text-transform: uppercase;
+        vertical-align: middle;
+        color: var(--charcoal);
+      }
+
+      svg {
+        position: relative;
+        top: 0;
+        margin-left: 0.5rem;
+        fill: none;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke: hsl(357, 37%, 62%);
+        stroke-width: 2;
+        transform: translateX(-0.5rem);
+        transition: all 0.3s ease;
+      }
+
+      &:hover {
+        &:before {
+          width: 9%;
+          background: #ffab9d;
+        }
+
+        svg {
+          transform: translateX(0);
+        }
+
+        .active {
+          transform: scale(0.96);
+        }
+      }
+    }
 
 
 
@@ -997,7 +1070,7 @@
 
 
     .chapter-card {
-      height: 60rem;
+      height: 50rem;
       /* Adjust margin as needed */
       box-shadow: 0 0.4rem 0.8rem rgba(0, 0, 0, 0.1);
       /* Add shadow for depth effect */
@@ -2513,7 +2586,7 @@
 
 
       .chapter-card {
-        height: 60rem;
+        height: 50rem;
         /* Adjust margin as needed */
         box-shadow: 0 0.4rem 0.8rem rgba(0, 0, 0, 0.1);
         /* Add shadow for depth effect */
@@ -4879,7 +4952,6 @@ color: #ac2127;
 
             <ul class="grid-list" id="genre-list" >
               <li data-aos="slide-right">
-                <a href="classic-literature.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
                     <p class="card-subtitle">01</p>
                     <div class="iconrow">
@@ -4895,21 +4967,18 @@ color: #ac2127;
                       are
                       all writers whose works are considered classical literature.
                     </p>
-                    <p class="book-recommendation">
-                      Book Recommendations:
-                    </p>
-                    <ul class="book-list">
-                      <li>1. Pride and Prejudice by Jane Austen</li>
-                      <li>2. Moby-Dick by Herman Melville </li>
-                      <li>3. 1984 by George Orwell</li>
-                    </ul>
 
+                    <a href="./classic-literature.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                   </div>
-                </a>
               </li>
 
               <li data-aos="zoom-in">
-                <a href="../assets/html/romance.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card" >
 
                   <p class="card-subtitle" style=" width: 202.48px; height: 13px;">02</p>
@@ -4924,21 +4993,18 @@ color: #ac2127;
                     the main characters of the story. The biggest defining characteristic of the romance genre is that a
                     happy ending is always guaranteed, perhaps living 'happily ever after.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Pride and Prejudice by Jane Austen</li>
-                    <li>2. The Notebook by Nicholas Sparks</li>
-                    <li>3. Me Before You by Jojo Moyes Lee</li>
-                  </ul>
+                  <a href="../assets/html/romance.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-              </a>
               </li>
 
               <li data-aos="slide-left">
-                <a href="../assets/html/suspense-thriller.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">03</p>
@@ -4953,21 +5019,18 @@ color: #ac2127;
                     with twists and turns, keeping readers guessing until the very last page as protagonists navigate
                     dangerous situations.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Gone Girl by Gillian Flynn</li>
-                    <li>2. The Girl with the Dragon Tattoo by Stieg Larsson</li>
-                    <li>3. The Da Vinci Code by Dan Brown</li>
-                  </ul>
+                  <a href="../assets/html/suspense-thriller.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-                </a>
               </li>
 
               <li data-aos="slide-right">
-                <a href="../assets/html/science-fiction.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">04</p>
@@ -4982,21 +5045,18 @@ color: #ac2127;
                     fiction books ignite the imagination with visions of advanced civilizations, space exploration, and
                     speculative science.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Dune by Frank Herbert</li>
-                    <li>2. Neuromancer by William Gibson</li>
-                    <li>3. The Hitchhiker's Guide to the Galaxy by Douglas Adams</li>
-                  </ul>
+                  <a href="../assets/html/science-fiction.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-                </a>
               </li>
 
               <li data-aos="zoom-in">
-                <a href="../assets/html/fantasy.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">05</p>
@@ -5010,21 +5070,18 @@ color: #ac2127;
                     anything is possible, weaving tales of epic quests, ancient prophecies, and battles between good and
                     evil.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Hobbit by J.R.R. Tolkien </li>
-                    <li>2. Harry Potter and the Sorcerer's Stone by J.K. Rowling </li>
-                    <li>3. A Game of Thrones by George R.R. Martin</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-                </a>
               </li>
 
               <li data-aos="slide-left">
-                <a href="../assets/html/horror.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">06</p>
@@ -5038,17 +5095,15 @@ color: #ac2127;
                     exploring fear, dread, and the unknown through chilling tales of monsters, ghosts, and psychological
                     terror.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Dracula by Bram Stoker </li>
-                    <li>2. The Shining by Stephen King</li>
-                    <li>3. Frankenstein by Mary Shelley </li>
-                  </ul>
+                  <a href="../assets/html/horror.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-              </a>
               </li>
 
               <li data-aos="slide-right">
@@ -5067,14 +5122,13 @@ color: #ac2127;
                     struggles of notable individuals, offering inspiration and understanding through their personal
                     stories and achievements.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Diary of a Young Girl by Anne Frank</li>
-                    <li>2. Long Walk to Freedom by Nelson Mandela</li>
-                    <li>3. Steve Jobs by Walter Isaacson</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </a>
@@ -5095,14 +5149,13 @@ color: #ac2127;
                     strategies, and insights for personal growth, happiness, and success, covering topics such as
                     relationships, productivity, and mental health.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The 7 Habits of Highly Effective People by Stephen R. Covey </li>
-                    <li>2. The Alchemist by Paulo Coelho</li>
-                    <li>3. Atomic Habits" by James Clear</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
                 </a>
@@ -5122,14 +5175,13 @@ color: #ac2127;
                     narratives, transporting readers to different eras and cultures, bringing history to life through
                     vivid characters and immersive storytelling.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Book Thief by Markus Zusak </li>
-                    <li>2. All the Light We Cannot See by Anthony Doerr</li>
-                    <li>3. The Nightingal" by Kristin Hannah </li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </a>
@@ -5151,14 +5203,13 @@ color: #ac2127;
                     From ancient epics to modern verses, they celebrate the power of words and the timeless beauty of
                     human expression.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Waste Land by T.S. Eliot</li>
-                    <li>2. Leaves of Grass by Walt Whitman</li>
-                    <li>3. The Sun and Her Flowers by Rupi Kaur </li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5178,14 +5229,13 @@ color: #ac2127;
                     and knowledge, they provoke deep thought, challenge assumptions, and offer
                     diverse perspectives, fostering critical thinking and a deeper understanding of the human condition.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Meditations by Marcus Aurelius</li>
-                    <li>2. The Republic by Plato </li>
-                    <li>3. Nicomachean Ethics by Aristotle</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5204,14 +5254,13 @@ color: #ac2127;
                     transports readers to exotic locales, ignites the imagination, and offers escapism,
                     excitement, and a sense of discovery and wonder.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Treasure Island by Robert Louis Stevenson</li>
-                    <li>2. The Call of the Wild by Jack London</li>
-                    <li>3. Life of Pi by Yann Martel</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5230,14 +5279,13 @@ color: #ac2127;
                     Dive into the mysteries and secrets of the world surrounding us, and gain a deeper knowledge and
                     history behind the wisdom of our correspondants and predecessors, through non-fiction.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Sapiens: A Brief History of Humankind by Yuval Noah Harari</li>
-                    <li>2. Educated by Tara Westover</li>
-                    <li>3. The Immortal Life of Henrietta Lacks by Rebecca Skloot</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5255,14 +5303,13 @@ color: #ac2127;
                     Are you feeling blue and want a good laugh? Well then, Comedy is the right genre for you! Grab a cup
                     of coffee, lean back and dive into a world of humour, smiles and all sun!
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Hitchhiker's Guide to the Galaxy by Douglas Adams</li>
-                    <li>2. Good Omens by Neil Gaiman and Terry Pratchett</li>
-                    <li>3. Bossypants by Tina Fey</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5282,14 +5329,13 @@ color: #ac2127;
                     reach your end-goal with secret agents. Put your investigative and observative skills to the test,
                     in the land of Detective Fiction.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Hound of the Baskervilles by Arthur Conan Doyle</li>
-                    <li>2. Gone Girl by Gillian Flynn</li>
-                    <li>3. The Big Sleep by Raymond Chandler</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5306,14 +5352,13 @@ color: #ac2127;
                     vanquished. The essence of fairy tales is their promise of a happy ending, with characters finding
                     their "happily ever after."
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Grimm's Fairy Tales by Jacob and Wilhelm Grimm</li>
-                    <li>2. Cinderella by Charles Perrault</li>
-                    <li>3. The Snow Queen by Hans Christian Andersen</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                 </div>
               </li>
               <li data-aos="zoom-in">
@@ -5329,14 +5374,13 @@ color: #ac2127;
                     generations. These tales often feature gods, heroes, and mythical creatures, exploring themes of
                     creation, morality, and the human condition.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Mythology: Timeless Tales of Gods and Heroes by Edith Hamilton </li>
-                    <li>2. The Iliad by Homer</li>
-                    <li>3. Norse Mythology by Neil Gaiman</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                 </div>
               </li>
               <li data-aos="slide-left">
@@ -5353,14 +5397,13 @@ color: #ac2127;
                     environments and explore themes of crime, corruption, and existential despair.
                   </p>
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Double Indemnity by James M. Cain</li>
-                    <li>2. The Maltese Falcon by Dashiell Hammett</li>
-                    <li>3. The Postman Always Rings Twice by James M. Cain</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                 </div>
               </li>
               <li data-aos="slide-right">
@@ -5376,14 +5419,13 @@ color: #ac2127;
                     justice system through detailed and factual narratives. These stories often provide deep insights
                     into criminal minds and the complex pursuit of justice.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. In Cold Blood by Truman Capote</li>
-                    <li>2. The Devil in the White City by Erik Larson</li>
-                    <li>3. I'll Be Gone in the Dark by Michelle McNamara </li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                 </div>
 
               </li>
@@ -5402,14 +5444,13 @@ color: #ac2127;
                     oppression, deprivation, and despair. These stories challenge readers to reflect on current social
                     and political issues by presenting exaggerated consequences of modern-day problems.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. 1984 by George Orwell</li>
-                    <li>2. Fahrenheit 451 by Ray Bradbury</li>
-                    <li>3. The Handmaid's Tale by Margaret Atwood</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5428,14 +5469,13 @@ color: #ac2127;
                     of everyday life. This genre often explores the boundaries between reality and imagination, weaving
                     fantastical occurrences into the fabric of the mundane.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Chronicles of Narnia by C.S. Lewis</li>
-                    <li>2. Alice's Adventures in Wonderland by Lewis Carroll</li>
-                    <li>3. The Night Circus by Erin Morgenstern</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5456,14 +5496,13 @@ color: #ac2127;
                     technology on human life, including issues of cybernetics, artificial intelligence, and corporate
                     control.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Neuromancer by William Gibson</li>
-                    <li>2. Snow Crash by Neal Stephenson</li>
-                    <li>3. Altered Carbon by Richard K. Morgan</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5482,14 +5521,13 @@ color: #ac2127;
                     perfect. These stories often explore theoretical models of how human society might function in an
                     ideal state, offering a contrast to real-world issues and inspiring visions of a better future.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Utopia by Thomas More</li>
-                    <li>2. Brave New World by Aldous Huxley</li>
-                    <li>3. The Dispossessed by Ursula K. Le Guin</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5508,14 +5546,13 @@ color: #ac2127;
                     genre is known for its innovative approaches, including fragmented narratives, unconventional
                     formats, and metafictional elements, pushing the boundaries of traditional storytelling.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. House of Leaves by Mark Z. Danielewski</li>
-                    <li>2. Ulysses by James Joyce</li>
-                    <li>3. If on a winter's night a traveler by Italo Calvino</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5533,14 +5570,13 @@ color: #ac2127;
                     through verbal ingenuity, swift perception and the human understanding of sarcasm and irony in
                     real-life.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Animal Farm by George Orwell</li>
-                    <li>2. Catch-22 by Joseph Heller</li>
-                    <li>3. The Hitchhiker's Guide to the Galaxy by Douglas Adams</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                 </div>
               </li>
 
@@ -5559,14 +5595,13 @@ color: #ac2127;
                     unreliable narrators. They keep you guessing with twists and explore complex, often dark,
                     motivations.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Gone Girl by Gillian Flynn</li>
-                    <li>2. The Girl on the Train by Paula Hawkins</li>
-                    <li>3. Shutter Island by Dennis Lehane</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </li>
@@ -5583,15 +5618,13 @@ color: #ac2127;
                     reflection on their experiences.It serves as a means for the author to share their unique narrative,
                     including the challenges they've faced and the lessons they've learned along the way.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Story of My Life by Helen Keller</li>
-                    <li>2. Becoming by Michelle Obama</li>
-                    <li>3. Educated by Tara Westover</li>
-                  </ul>
-
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                 </div>
               </li>
             </ul>

--- a/repo_structure.txt
+++ b/repo_structure.txt
@@ -103,6 +103,7 @@
 │   │   │       └── event.css
 │   │   ├── audio.html
 │   │   ├── author.html
+│   │   ├── biography.html
 │   │   ├── blog.html
 │   │   ├── book_recommend.html
 │   │   ├── booking.html
@@ -119,6 +120,7 @@
 │   │   ├── freeBooks.html
 │   │   ├── god.html
 │   │   ├── googlece7a206a6cfbb7ed.html
+│   │   ├── historical-fiction.html
 │   │   ├── horror.html
 │   │   ├── image.png
 │   │   ├── img.png
@@ -139,15 +141,19 @@
 │   │   ├── romance.html
 │   │   ├── school.html
 │   │   ├── science-fiction.html
+│   │   ├── self-help.html
 │   │   ├── social.html
 │   │   ├── suspense-thriller.html
 │   │   ├── tips.html
 │   │   └── top10.html
 │   ├── images/
+│   │   ├── 1984.jpg
 │   │   ├── FB icon.png
 │   │   ├── LogoPicDark.png
 │   │   ├── LogoPicLight.png
+│   │   ├── Madame Bovary.webp
 │   │   ├── Screenshot 2024-10-28 at 12.09.51 AM
+│   │   ├── The Picture of Dorian Gray.jpg
 │   │   ├── TheGuide.jpg
 │   │   ├── Wings_of_Fire_by_A_P_J_Abdul_Kalam_Book_Cover.jpg
 │   │   ├── YT icon.png
@@ -157,6 +163,9 @@
 │   │   ├── achievement-3.jpg
 │   │   ├── achievement-4.jpg
 │   │   ├── achievement-5.jpg
+│   │   ├── alter.jpeg
+│   │   ├── american.jpg
+│   │   ├── anna_karenina.jpg
 │   │   ├── author-banner.png
 │   │   ├── avatar1.jpg
 │   │   ├── avatar2.jpg
@@ -165,12 +174,17 @@
 │   │   ├── avatar5.jpg
 │   │   ├── award.svg
 │   │   ├── be.jpeg
+│   │   ├── beach.jpg
+│   │   ├── bear.jpg
+│   │   ├── before.jpg
+│   │   ├── behind.jpg
 │   │   ├── benefits-1.svg
 │   │   ├── benefits-2.svg
 │   │   ├── benefits-3.svg
 │   │   ├── benefits-4.svg
 │   │   ├── benefits-5.svg
 │   │   ├── benefits-6.svg
+│   │   ├── big.jpg
 │   │   ├── book/
 │   │   │   ├── Army.jpg
 │   │   │   ├── Economist.jpg
@@ -187,6 +201,11 @@
 │   │   ├── books_swapRead.jpg
 │   │   ├── bookshelf.png
 │   │   ├── bookshelfhover.png
+│   │   ├── brave.jpeg
+│   │   ├── brothers_karamazov.jpg
+│   │   ├── catcher_in_the_rye.jpg
+│   │   ├── chain.jpg
+│   │   ├── city.jpeg
 │   │   ├── cl.jpg
 │   │   ├── close-white.png
 │   │   ├── close.png
@@ -195,12 +214,18 @@
 │   │   ├── community.png
 │   │   ├── communityhover.png
 │   │   ├── contact.png
+│   │   ├── couple.jpg
+│   │   ├── court.jpg
+│   │   ├── crime_and_punishment.jpg
 │   │   ├── ctc1.png
 │   │   ├── ctc2.png
 │   │   ├── ctc3.png
 │   │   ├── ctc4.png
 │   │   ├── ctc5.png
 │   │   ├── darkmode_bg.png
+│   │   ├── dracula.webp
+│   │   ├── duno.jpeg
+│   │   ├── duno.jpg
 │   │   ├── edit profile.jpg
 │   │   ├── em.jpeg
 │   │   ├── emoji/
@@ -209,10 +234,16 @@
 │   │   │   ├── emoji-3.png
 │   │   │   ├── emoji-4.png
 │   │   │   └── emoji-5.png
+│   │   ├── enders.jpg
 │   │   ├── eye-close.png
 │   │   ├── eye-open.png
+│   │   ├── fahrenheit.jpeg
 │   │   ├── fantasy.jpg
+│   │   ├── fates.jpg
 │   │   ├── final.png
+│   │   ├── foundation.jpeg
+│   │   ├── frankenstein.jpg
+│   │   ├── game.jpg
 │   │   ├── genres/
 │   │   │   ├── 1.jpg
 │   │   │   ├── 10.jpg
@@ -228,13 +259,25 @@
 │   │   │   ├── auth2.jpg
 │   │   │   ├── auth3.jpg
 │   │   │   └── c1.jpg
+│   │   ├── girl.jpg
+│   │   ├── gone.jpg
 │   │   ├── good of small tjings.jpg
 │   │   ├── google button.jpeg
 │   │   ├── google icon.jpeg
 │   │   ├── gr.jpeg
+│   │   ├── great-expectations.jpeg
+│   │   ├── great_gatsby.jpg
+│   │   ├── guest.jpg
+│   │   ├── harry.jpg
+│   │   ├── hating.jpg
 │   │   ├── help.png
 │   │   ├── hero-banner.png
 │   │   ├── hero-section.avif
+│   │   ├── hitcher.jpeg
+│   │   ├── hobbit.jpg
+│   │   ├── hola.jpg
+│   │   ├── honey.jpg
+│   │   ├── hype.jpeg
 │   │   ├── icons8-sun.svg
 │   │   ├── images/
 │   │   │   ├── b.jpg
@@ -248,24 +291,43 @@
 │   │   ├── inbox.png
 │   │   ├── india after gandhi.jpg
 │   │   ├── insta icon.png
+│   │   ├── itends.jpg
 │   │   ├── ja.jpeg
+│   │   ├── jane_eyre.jpg
 │   │   ├── jk.jpeg
 │   │   ├── jo.jpeg
+│   │   ├── kiss.jpg
+│   │   ├── left.jpeg
+│   │   ├── les.jpg
+│   │   ├── lock.jpg
 │   │   ├── logo_darkbg.png
 │   │   ├── logo_whitebg.png
 │   │   ├── logout.png
 │   │   ├── ma.jpg
+│   │   ├── martian.jpeg
+│   │   ├── mebeforeyou.jpg
 │   │   ├── mg.jpeg
 │   │   ├── midnight children.jpg
+│   │   ├── mist.jpg
+│   │   ├── moby.jpg
 │   │   ├── moon.png
 │   │   ├── moon_solid.svg
 │   │   ├── mystery.jpg
+│   │   ├── name.jpg
+│   │   ├── narnia.jpg
 │   │   ├── ne.jpeg
 │   │   ├── nes.jpeg
+│   │   ├── neuro.jpeg
 │   │   ├── new_logo.png
 │   │   ├── new_logo_banner_dark.png
 │   │   ├── new_logo_banner_light.png
 │   │   ├── new_logo_dark.png
+│   │   ├── night.jpg
+│   │   ├── notebook.jpeg
+│   │   ├── odyssey.jpg
+│   │   ├── oryx.jpeg
+│   │   ├── oryx.jpg
+│   │   ├── outlander.jpg
 │   │   ├── philopsphy.jpg
 │   │   ├── pic1.jpeg
 │   │   ├── pic2.jpeg
@@ -276,13 +338,22 @@
 │   │   ├── preview-3.png
 │   │   ├── preview-4.png
 │   │   ├── preview-5.png
+│   │   ├── pride.jpg
+│   │   ├── priory.jpg
 │   │   ├── re.jpg
 │   │   ├── read.png
 │   │   ├── readhover.png
+│   │   ├── ready.jpeg
+│   │   ├── red.jpg
 │   │   ├── rom.jpg
+│   │   ├── rosie.jpg
+│   │   ├── scarlet.jpg
 │   │   ├── sci.jpg
 │   │   ├── settings.png
 │   │   ├── shantaram.jpg
+│   │   ├── shutter.jpg
+│   │   ├── silent.jpg
+│   │   ├── snow.jpeg
 │   │   ├── sun.png
 │   │   ├── tele.png
 │   │   ├── telephone.png
@@ -294,6 +365,7 @@
 │   │   ├── testimonials-6.jpg
 │   │   ├── the inheritance of book.jpg
 │   │   ├── thriller.jpg
+│   │   ├── to_kill_a_mockingbird.png
 │   │   ├── train to paki.jpg
 │   │   ├── trendingbook1.jpg
 │   │   ├── trendingbook2.jpg
@@ -303,9 +375,16 @@
 │   │   ├── true crime.jpg
 │   │   ├── twitter-icon.png
 │   │   ├── twitter.png
+│   │   ├── uprooted.jpg
 │   │   ├── user.jpg
+│   │   ├── war.jpeg
 │   │   ├── website-ss.png
-│   │   └── white tiger.jpg
+│   │   ├── wheel.jpg
+│   │   ├── white tiger.jpg
+│   │   ├── wife.jpg
+│   │   ├── wild.jpg
+│   │   ├── woman.jpg
+│   │   └── wuthering_heights.jpg
 │   ├── js/
 │   │   ├── ReaderConn.js
 │   │   ├── addremove.js
@@ -372,10 +451,10 @@
 ├── connectWithsame.html
 ├── contactus1.html
 ├── contributing.txt
-├── contributors/
-│   ├── contributor.css
-│   ├── contributor.html
-│   └── contributor.js
+├── contributor/
+│   ├── contributorss.css
+│   ├── contributorss.html
+│   └── contributorss.js
 ├── controller/
 │   ├── Rating.js
 │   ├── book.js


### PR DESCRIPTION
# Related Issue

[Cite any related issue(s) this pull request addresses. If none, simply state “None”]

Fixes:  #4548 

# Description

Since different pages have been created for specific genre of books, I have removed the recommended books written in text (in genre section of home pg) and replaced them with buttons leading to pages consisting of diff genre of books. (works in both light and dark mode)

<!---give the issue number you fixed----->

# Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes. Make sure to attach before & after screenshots in your PR.]



before:
![image](https://github.com/user-attachments/assets/72370e55-b0ca-4116-9bee-05f178530abb)

after:
![image](https://github.com/user-attachments/assets/8124aac2-c190-4da6-9ddb-de10d14de4f1)
![image](https://github.com/user-attachments/assets/9e0af9dd-79f4-4fa9-bdb6-c6e843bb3a06)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [ ] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have tested the changes thoroughly before submitting this pull request.
- [ ] I have provided relevant issue numbers and screenshots after making the changes.

