### PR TITLE
🛠️FIX : Book swapping page User avatar fetching error

### DIFF
--- a/assets/html/booklistswap.html
+++ b/assets/html/booklistswap.html
@@ -746,7 +746,7 @@
         const savedAvatar = localStorage.getItem("selectedAvatar");
         const savedName = localStorage.getItem("profileName");
         if (savedAvatar) {
-          document.getElementById("profile-avatar").src = `./assets/images/${savedAvatar}`;
+          document.getElementById("profile-avatar").src = `../images/${savedAvatar}`;
         }
 
         if (savedName) {


### PR DESCRIPTION
# Related Issue

“None”

Fixes:  #4574

# Description

On the Books swapping page, the user avatar was not fetching from local storage, It was showing a blank space instead. It fixed that.

# Type of PR

- [x] Bug fix
- [x] Feature enhancement


# Screenshots / videos (if applicable)
![image](https://github.com/user-attachments/assets/d0779545-5687-48a8-ae41-8a5a2cb90c6b)


# Checklist:

- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

