### PR TITLE
adding buttons in genre section of home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@
 ├── Mystical-fantaies.html
 ├── README.md
 ├── SECURITY.md
+├── activity.css
+├── activity.html
+├── activity.js
 ├── address.css
 ├── address.html
 ├── assets/
@@ -167,12 +170,17 @@
 │   │   ├── bookpref.html
 │   │   ├── borrow.html
 │   │   ├── checkout.html
+│   │   ├── classic.html
 │   │   ├── comedy.html
 │   │   ├── comsp.html
 │   │   ├── custom.html
+│   │   ├── cyberpunk.html
 │   │   ├── detective-fiction.html
 │   │   ├── donate.html
+│   │   ├── dystopian.html
 │   │   ├── event.html
+│   │   ├── experimental-fiction.html
+│   │   ├── fairytale.html
 │   │   ├── fantasy.html
 │   │   ├── forgot-pass.html
 │   │   ├── freeBooks.html
@@ -183,16 +191,20 @@
 │   │   ├── image.png
 │   │   ├── img.png
 │   │   ├── login.html
+│   │   ├── magical-realism.html
 │   │   ├── maha.html
 │   │   ├── map.html
 │   │   ├── midnight.html
 │   │   ├── mood.html
 │   │   ├── mylogin.html
+│   │   ├── mythology.html
 │   │   ├── ngo.html
+│   │   ├── noir.html
 │   │   ├── nonfiction.html
 │   │   ├── philosophy.html
 │   │   ├── poetry.html
 │   │   ├── profileedit.html
+│   │   ├── psycological-thriller.html
 │   │   ├── quiz.html
 │   │   ├── quizzes.html
 │   │   ├── ram.html
@@ -200,13 +212,16 @@
 │   │   ├── read.html
 │   │   ├── read_later.html
 │   │   ├── romance.html
+│   │   ├── satire.html
 │   │   ├── school.html
 │   │   ├── science-fiction.html
 │   │   ├── self-help.html
 │   │   ├── social.html
 │   │   ├── suspense-thriller.html
 │   │   ├── tips.html
-│   │   └── top10.html
+│   │   ├── top10.html
+│   │   ├── true-crime.html
+│   │   └── utopian.html
 │   ├── images/
 │   │   ├── 1984.jpg
 │   │   ├── FB icon.png
@@ -285,6 +300,7 @@
 │   │   ├── ctc5.png
 │   │   ├── darkmode_bg.png
 │   │   ├── dracula.webp
+│   │   ├── dune.jpg
 │   │   ├── duno.jpeg
 │   │   ├── duno.jpg
 │   │   ├── edit profile.jpg
@@ -506,7 +522,6 @@
 ├── chat.css
 ├── chat.html
 ├── chat.js
-├── classic-literature.html
 ├── cod.jpg
 ├── comsp.html
 ├── connectWithsame.html

--- a/index.html
+++ b/index.html
@@ -739,6 +739,7 @@
           }
         }
 
+
       .price{
         font-weight: 800;
         font-size: 20px;
@@ -4990,7 +4991,7 @@ color: #ac2127;
               <span class="span has-before"></span>
             </h2>
 
-             <ul class="grid-list" id="genre-list" >
+            <ul class="grid-list" id="genre-list" >
               <li data-aos="slide-right">
                 <div class="chapter-card">
                     <p class="card-subtitle">01</p>
@@ -5665,146 +5666,6 @@ color: #ac2127;
                         <polyline points="8 1 12 5 8 9"></polyline>
                       </svg>
                     </a>
-                </div>
-              </li>
-            </ul>
-
-                </div>
-                </a>
-              </li>
-
-              <li data-aos="zoom-in">
-                <a href="../assets/html/utopian.html" style="text-decoration: none; color: inherit;">
-                <div class="chapter-card">
-
-                  <p class="card-subtitle">23</p>
-                  <div class="iconrow">
-                    <h3 class="h3 card-title">Utopian</h3>
-                    <span style='font-size:5rem;filter: grayscale(100%);'>&#x1F3DD;</span>
-                  </div>
-
-                  <p class="card-text">
-                    Utopian fiction presents idealized societies where social, political, and economic conditions are
-                    perfect. These stories often explore theoretical models of how human society might function in an
-                    ideal state, offering a contrast to real-world issues and inspiring visions of a better future.
-                  </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Utopia by Thomas More</li>
-                    <li>2. Brave New World by Aldous Huxley</li>
-                    <li>3. The Dispossessed by Ursula K. Le Guin</li>
-                  </ul>
-
-                </div>
-                </a>
-              </li>
-
-              <li data-aos="slide-left">
-                <a href="../assets/html/experimental-fiction.html" style="text-decoration: none; color: inherit;">
-                <div class="chapter-card">
-
-                  <p class="card-subtitle">24</p>
-                  <div class="iconrow">
-                    <h3 class="h3 card-title">Experimental Fiction</h3>
-                    <span style='font-size:5rem;filter: grayscale(100%);'>&#x1F4DA;</span>
-                  </div>
-
-                  <p class="card-text">
-                    Experimental Fiction challenges conventional narrative structures and storytelling techniques. This
-                    genre is known for its innovative approaches, including fragmented narratives, unconventional
-                    formats, and metafictional elements, pushing the boundaries of traditional storytelling.
-                  </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. House of Leaves by Mark Z. Danielewski</li>
-                    <li>2. Ulysses by James Joyce</li>
-                    <li>3. If on a winter's night a traveler by Italo Calvino</li>
-                  </ul>
-
-                </div>
-                </a>
-              </li>
-
-              <li data-aos="slide-right">
-                <a href="../assets/html/satire.html" style="text-decoration: none; color: inherit;">
-                <div class="chapter-card">
-                  <p class="card-subtitle">25</p>
-                  <div class="iconrow">
-                    <h3 class="h3 card-title">Satire</h3>
-                    <span style='font-size:5rem;filter: grayscale(100%);'>&#x1F3AD;</span>
-                  </div>
-
-                  <p class="card-text">
-                    A tribute to the visual, literary and performing arts, Satire books can give you a good laugh
-                    through verbal ingenuity, swift perception and the human understanding of sarcasm and irony in
-                    real-life.
-                  </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Animal Farm by George Orwell</li>
-                    <li>2. Catch-22 by Joseph Heller</li>
-                    <li>3. The Hitchhiker's Guide to the Galaxy by Douglas Adams</li>
-                  </ul>
-                </div>
-              </a>
-              </li>
-
-              </li>
-              <li data-aos="zoom-in">
-                <a href="../assets/html/psycological-thriller.html" style="text-decoration: none; color: inherit;">
-                <div class="chapter-card">
-
-                  <p class="card-subtitle">26</p>
-                  <div class="iconrow">
-                    <h3 class="h3 card-title">Psychological Thriller</h3>
-                    <span style='font-size:5rem;filter: grayscale(100%);'>&#x23F3;</span>
-                  </div>
-
-                  <p class="card-text">
-                    Psychological thrillers delve into the human psyche, creating suspense through mind games and
-                    unreliable narrators. They keep you guessing with twists and explore complex, often dark,
-                    motivations.
-                  </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Gone Girl by Gillian Flynn</li>
-                    <li>2. The Girl on the Train by Paula Hawkins</li>
-                    <li>3. Shutter Island by Dennis Lehane</li>
-                  </ul>
-
-                </div>
-                </a>
-              </li>
-
-              <li data-aos="slide-left">
-                <div class="chapter-card">
-
-                  <p class="card-subtitle">27</p>
-
-                  <h3 class="h3 card-title">Autobiography</h3>
-
-                  <p class="card-text">
-                    A non-fiction account of a person's life written by that person, offering personal insight and
-                    reflection on their experiences.It serves as a means for the author to share their unique narrative,
-                    including the challenges they've faced and the lessons they've learned along the way.
-                  </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Story of My Life by Helen Keller</li>
-                    <li>2. Becoming by Michelle Obama</li>
-                    <li>3. Educated by Tara Westover</li>
-                  </ul>
-
                 </div>
               </li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -5009,7 +5009,7 @@ color: #ac2127;
                       all writers whose works are considered classical literature.
                     </p>
 
-                    <a href="./classic-literature.html" class="cta2 style-9">
+                    <a href="../assets/html/classic.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5148,7 +5148,6 @@ color: #ac2127;
               </li>
 
               <li data-aos="slide-right">
-                <a href="../assets/html/biography.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">07</p>
@@ -5163,7 +5162,7 @@ color: #ac2127;
                     struggles of notable individuals, offering inspiration and understanding through their personal
                     stories and achievements.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/biography.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5172,11 +5171,9 @@ color: #ac2127;
                     </a>
 
                 </div>
-              </a>
               </li>
 
               <li data-aos="zoom-in">
-                <a href="../assets/html/self-help.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">08</p>
@@ -5190,7 +5187,7 @@ color: #ac2127;
                     strategies, and insights for personal growth, happiness, and success, covering topics such as
                     relationships, productivity, and mental health.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/self-help.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5199,10 +5196,9 @@ color: #ac2127;
                     </a>
 
                 </div>
-                </a>
               </li>
+
               <li data-aos="slide-left">
-                <a href="../assets/html/historical-fiction.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">09</p>
@@ -5216,7 +5212,7 @@ color: #ac2127;
                     narratives, transporting readers to different eras and cultures, bringing history to life through
                     vivid characters and immersive storytelling.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/historical-fiction.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5225,7 +5221,6 @@ color: #ac2127;
                     </a>
 
                 </div>
-              </a>
               </li>
 
               <li data-aos="slide-right" >
@@ -5244,7 +5239,7 @@ color: #ac2127;
                     From ancient epics to modern verses, they celebrate the power of words and the timeless beauty of
                     human expression.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/poetry.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5270,7 +5265,7 @@ color: #ac2127;
                     and knowledge, they provoke deep thought, challenge assumptions, and offer
                     diverse perspectives, fostering critical thinking and a deeper understanding of the human condition.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/philosophy.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5295,7 +5290,7 @@ color: #ac2127;
                     transports readers to exotic locales, ignites the imagination, and offers escapism,
                     excitement, and a sense of discovery and wonder.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/adventure.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5320,7 +5315,7 @@ color: #ac2127;
                     Dive into the mysteries and secrets of the world surrounding us, and gain a deeper knowledge and
                     history behind the wisdom of our correspondants and predecessors, through non-fiction.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/nonfiction.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5344,7 +5339,7 @@ color: #ac2127;
                     Are you feeling blue and want a good laugh? Well then, Comedy is the right genre for you! Grab a cup
                     of coffee, lean back and dive into a world of humour, smiles and all sun!
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/comedy.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5370,7 +5365,7 @@ color: #ac2127;
                     reach your end-goal with secret agents. Put your investigative and observative skills to the test,
                     in the land of Detective Fiction.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/detective-fiction.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5393,7 +5388,7 @@ color: #ac2127;
                     vanquished. The essence of fairy tales is their promise of a happy ending, with characters finding
                     their "happily ever after."
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/fairytale.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5415,7 +5410,7 @@ color: #ac2127;
                     generations. These tales often feature gods, heroes, and mythical creatures, exploring themes of
                     creation, morality, and the human condition.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/mythology.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5438,7 +5433,7 @@ color: #ac2127;
                     environments and explore themes of crime, corruption, and existential despair.
                   </p>
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/noir.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5460,7 +5455,7 @@ color: #ac2127;
                     justice system through detailed and factual narratives. These stories often provide deep insights
                     into criminal minds and the complex pursuit of justice.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/true-crime.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5485,7 +5480,7 @@ color: #ac2127;
                     oppression, deprivation, and despair. These stories challenge readers to reflect on current social
                     and political issues by presenting exaggerated consequences of modern-day problems.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/dystopian.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5510,7 +5505,7 @@ color: #ac2127;
                     of everyday life. This genre often explores the boundaries between reality and imagination, weaving
                     fantastical occurrences into the fabric of the mundane.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/magical-realism.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5537,7 +5532,7 @@ color: #ac2127;
                     technology on human life, including issues of cybernetics, artificial intelligence, and corporate
                     control.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/cyberpunk.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5562,7 +5557,7 @@ color: #ac2127;
                     perfect. These stories often explore theoretical models of how human society might function in an
                     ideal state, offering a contrast to real-world issues and inspiring visions of a better future.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/utopian.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5587,7 +5582,7 @@ color: #ac2127;
                     genre is known for its innovative approaches, including fragmented narratives, unconventional
                     formats, and metafictional elements, pushing the boundaries of traditional storytelling.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/experimental-fiction.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5611,7 +5606,7 @@ color: #ac2127;
                     through verbal ingenuity, swift perception and the human understanding of sarcasm and irony in
                     real-life.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/satire.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5636,7 +5631,7 @@ color: #ac2127;
                     unreliable narrators. They keep you guessing with twists and explore complex, often dark,
                     motivations.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/psycological-thriller.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
@@ -5659,7 +5654,7 @@ color: #ac2127;
                     reflection on their experiences.It serves as a means for the author to share their unique narrative,
                     including the challenges they've faced and the lessons they've learned along the way.
                   </p>
-                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                  <a href="../assets/html/biography.html" class="cta2 style-9">
                       <span style="font-size: 1.2rem;">Book Recommendations</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>

--- a/index.html
+++ b/index.html
@@ -665,7 +665,79 @@
         }
       }
     }
-
+    .cta2.style-9 {
+          position: absolute;
+          bottom: 40px; /* Positions the link 20px above the bottom of the card */
+      display: flex;
+      align-items: center;
+      text-decoration: none;
+      font-size: 1.2rem;
+    }
+    
+        .cta2 {
+          position: relative;
+          display: flex;
+          align-items: center;
+          justify-content: flex-start;
+          margin: auto;
+          padding: 2rem 2.4rem;
+          color: hsl(357, 37%, 62%);
+          font-family: Avenir, sans-serif;
+          text-decoration: none;
+          transition: all 0.2s ease;
+    
+          &:before {
+            content: "";
+            position: absolute;
+            top: 0;
+            left: 0;
+            display: block;
+            border-radius: 2.8rem;
+            background: rgba(255, 171, 157, 0.5);
+            width: 28rem;
+            height: 5.6rem;
+            transition: all 0.3s ease;
+          }
+    
+          span {
+            position: relative;
+            font-size: 0.8rem;
+            line-height: 1.8rem;
+            font-weight: 900;
+            letter-spacing: 0.25em;
+            text-transform: uppercase;
+            vertical-align: middle;
+            color: var(--charcoal);
+          }
+    
+          svg {
+            position: relative;
+            top: 0;
+            margin-left: 0.5rem;
+            fill: none;
+            stroke-linecap: round;
+            stroke-linejoin: round;
+            stroke: hsl(357, 37%, 62%);
+            stroke-width: 2;
+            transform: translateX(-0.5rem);
+            transition: all 0.3s ease;
+          }
+    
+          &:hover {
+            &:before {
+              width: 9%;
+              background: #ffab9d;
+            }
+    
+            svg {
+              transform: translateX(0);
+            }
+    
+            .active {
+              transform: scale(0.96);
+            }
+          }
+        }
 
       .price{
         font-weight: 800;
@@ -1000,7 +1072,7 @@
 
 
     .chapter-card {
-      height: 60rem;
+      height: 50rem;
       /* Adjust margin as needed */
       box-shadow: 0 0.4rem 0.8rem rgba(0, 0, 0, 0.1);
       /* Add shadow for depth effect */
@@ -2542,7 +2614,7 @@
 
 
       .chapter-card {
-        height: 60rem;
+        height: 50rem;
         /* Adjust margin as needed */
         box-shadow: 0 0.4rem 0.8rem rgba(0, 0, 0, 0.1);
         /* Add shadow for depth effect */
@@ -4918,9 +4990,8 @@ color: #ac2127;
               <span class="span has-before"></span>
             </h2>
 
-            <ul class="grid-list" id="genre-list" >
+             <ul class="grid-list" id="genre-list" >
               <li data-aos="slide-right">
-                <a href="./assets/html/classic.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
                     <p class="card-subtitle">01</p>
                     <div class="iconrow">
@@ -4936,21 +5007,18 @@ color: #ac2127;
                       are
                       all writers whose works are considered classical literature.
                     </p>
-                    <p class="book-recommendation">
-                      Book Recommendations:
-                    </p>
-                    <ul class="book-list">
-                      <li>1. Pride and Prejudice by Jane Austen</li>
-                      <li>2. Moby-Dick by Herman Melville </li>
-                      <li>3. 1984 by George Orwell</li>
-                    </ul>
 
+                    <a href="./classic-literature.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                   </div>
-                </a>
               </li>
 
               <li data-aos="zoom-in">
-                <a href="./assets/html/romance.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card" >
 
                   <p class="card-subtitle" style=" width: 202.48px; height: 13px;">02</p>
@@ -4965,21 +5033,18 @@ color: #ac2127;
                     the main characters of the story. The biggest defining characteristic of the romance genre is that a
                     happy ending is always guaranteed, perhaps living 'happily ever after.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Pride and Prejudice by Jane Austen</li>
-                    <li>2. The Notebook by Nicholas Sparks</li>
-                    <li>3. Me Before You by Jojo Moyes Lee</li>
-                  </ul>
+                  <a href="../assets/html/romance.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-              </a>
               </li>
 
               <li data-aos="slide-left">
-                <a href="./assets/html/suspense-thriller.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">03</p>
@@ -4994,21 +5059,18 @@ color: #ac2127;
                     with twists and turns, keeping readers guessing until the very last page as protagonists navigate
                     dangerous situations.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Gone Girl by Gillian Flynn</li>
-                    <li>2. The Girl with the Dragon Tattoo by Stieg Larsson</li>
-                    <li>3. The Da Vinci Code by Dan Brown</li>
-                  </ul>
+                  <a href="../assets/html/suspense-thriller.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-                </a>
               </li>
 
               <li data-aos="slide-right">
-                <a href="./assets/html/science-fiction.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">04</p>
@@ -5023,21 +5085,18 @@ color: #ac2127;
                     fiction books ignite the imagination with visions of advanced civilizations, space exploration, and
                     speculative science.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Dune by Frank Herbert</li>
-                    <li>2. Neuromancer by William Gibson</li>
-                    <li>3. The Hitchhiker's Guide to the Galaxy by Douglas Adams</li>
-                  </ul>
+                  <a href="../assets/html/science-fiction.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-                </a>
               </li>
 
               <li data-aos="zoom-in">
-                <a href="./assets/html/fantasy.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">05</p>
@@ -5051,21 +5110,18 @@ color: #ac2127;
                     anything is possible, weaving tales of epic quests, ancient prophecies, and battles between good and
                     evil.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Hobbit by J.R.R. Tolkien </li>
-                    <li>2. Harry Potter and the Sorcerer's Stone by J.K. Rowling </li>
-                    <li>3. A Game of Thrones by George R.R. Martin</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-                </a>
               </li>
 
               <li data-aos="slide-left">
-                <a href="../assets/html/horror.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">06</p>
@@ -5079,17 +5135,15 @@ color: #ac2127;
                     exploring fear, dread, and the unknown through chilling tales of monsters, ghosts, and psychological
                     terror.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Dracula by Bram Stoker </li>
-                    <li>2. The Shining by Stephen King</li>
-                    <li>3. Frankenstein by Mary Shelley </li>
-                  </ul>
+                  <a href="../assets/html/horror.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-              </a>
               </li>
 
               <li data-aos="slide-right">
@@ -5108,14 +5162,13 @@ color: #ac2127;
                     struggles of notable individuals, offering inspiration and understanding through their personal
                     stories and achievements.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Diary of a Young Girl by Anne Frank</li>
-                    <li>2. Long Walk to Freedom by Nelson Mandela</li>
-                    <li>3. Steve Jobs by Walter Isaacson</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </a>
@@ -5136,14 +5189,13 @@ color: #ac2127;
                     strategies, and insights for personal growth, happiness, and success, covering topics such as
                     relationships, productivity, and mental health.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The 7 Habits of Highly Effective People by Stephen R. Covey </li>
-                    <li>2. The Alchemist by Paulo Coelho</li>
-                    <li>3. Atomic Habits" by James Clear</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
                 </a>
@@ -5163,21 +5215,19 @@ color: #ac2127;
                     narratives, transporting readers to different eras and cultures, bringing history to life through
                     vivid characters and immersive storytelling.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Book Thief by Markus Zusak </li>
-                    <li>2. All the Light We Cannot See by Anthony Doerr</li>
-                    <li>3. The Nightingal" by Kristin Hannah </li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
               </a>
               </li>
 
               <li data-aos="slide-right" >
-                <a href="../assets/html/poetry.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">10</p>
@@ -5193,21 +5243,18 @@ color: #ac2127;
                     From ancient epics to modern verses, they celebrate the power of words and the timeless beauty of
                     human expression.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Waste Land by T.S. Eliot</li>
-                    <li>2. Leaves of Grass by Walt Whitman</li>
-                    <li>3. The Sun and Her Flowers by Rupi Kaur </li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-              </a>
               </li>
 
               <li data-aos="zoom-in">
-                <a href="../assets/html/philosophy.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">11</p>
@@ -5222,23 +5269,19 @@ color: #ac2127;
                     and knowledge, they provoke deep thought, challenge assumptions, and offer
                     diverse perspectives, fostering critical thinking and a deeper understanding of the human condition.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Meditations by Marcus Aurelius</li>
-                    <li>2. The Republic by Plato </li>
-                    <li>3. Nicomachean Ethics by Aristotle</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-              </a>
               </li>
 
               <li data-aos="slide-left">
-                <a href="../assets/html/adventure.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
-                
 
                   <p class="card-subtitle">12</p>
                   <div class="iconrow">
@@ -5251,22 +5294,19 @@ color: #ac2127;
                     transports readers to exotic locales, ignites the imagination, and offers escapism,
                     excitement, and a sense of discovery and wonder.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Treasure Island by Robert Louis Stevenson</li>
-                    <li>2. The Call of the Wild by Jack London</li>
-                    <li>3. Life of Pi by Yann Martel</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-              </a>
               </li>
 
               <!-- Added three more genres here-->
               <li data-aos="slide-right">
-                <a href="../assets/html/nonfiction.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">13</p>
@@ -5279,21 +5319,18 @@ color: #ac2127;
                     Dive into the mysteries and secrets of the world surrounding us, and gain a deeper knowledge and
                     history behind the wisdom of our correspondants and predecessors, through non-fiction.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Sapiens: A Brief History of Humankind by Yuval Noah Harari</li>
-                    <li>2. Educated by Tara Westover</li>
-                    <li>3. The Immortal Life of Henrietta Lacks by Rebecca Skloot</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-                </a>
               </li>
 
               <li data-aos="zoom-in">
-                <a href="../assets/html/comedy.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">14</p>
@@ -5306,21 +5343,18 @@ color: #ac2127;
                     Are you feeling blue and want a good laugh? Well then, Comedy is the right genre for you! Grab a cup
                     of coffee, lean back and dive into a world of humour, smiles and all sun!
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Hitchhiker's Guide to the Galaxy by Douglas Adams</li>
-                    <li>2. Good Omens by Neil Gaiman and Terry Pratchett</li>
-                    <li>3. Bossypants by Tina Fey</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-                </a>
               </li>
 
               <li data-aos="slide-left">
-                <a href="../assets/html/detective-fiction.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">15</p>
@@ -5335,20 +5369,17 @@ color: #ac2127;
                     reach your end-goal with secret agents. Put your investigative and observative skills to the test,
                     in the land of Detective Fiction.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Hound of the Baskervilles by Arthur Conan Doyle</li>
-                    <li>2. Gone Girl by Gillian Flynn</li>
-                    <li>3. The Big Sleep by Raymond Chandler</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-                </a>
               </li>
               <li data-aos="slide-right">
-                <a href="../assets/html/fairytale.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
                   <p class="card-subtitle">16</p>
                   <div class="iconrow">
@@ -5361,19 +5392,16 @@ color: #ac2127;
                     vanquished. The essence of fairy tales is their promise of a happy ending, with characters finding
                     their "happily ever after."
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Grimm's Fairy Tales by Jacob and Wilhelm Grimm</li>
-                    <li>2. Cinderella by Charles Perrault</li>
-                    <li>3. The Snow Queen by Hans Christian Andersen</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                 </div>
-                </a>
               </li>
               <li data-aos="zoom-in">
-                <a href="../assets/html/mythology.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
                   <p class="card-subtitle">17</p>
                   <div class="iconrow">
@@ -5386,19 +5414,16 @@ color: #ac2127;
                     generations. These tales often feature gods, heroes, and mythical creatures, exploring themes of
                     creation, morality, and the human condition.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Mythology: Timeless Tales of Gods and Heroes by Edith Hamilton </li>
-                    <li>2. The Iliad by Homer</li>
-                    <li>3. Norse Mythology by Neil Gaiman</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                 </div>
-                </a>
               </li>
               <li data-aos="slide-left">
-                <a href="../assets/html/noir.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
                   <p class="card-subtitle">18</p>
                   <div class="iconrow">
@@ -5412,19 +5437,16 @@ color: #ac2127;
                     environments and explore themes of crime, corruption, and existential despair.
                   </p>
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. Double Indemnity by James M. Cain</li>
-                    <li>2. The Maltese Falcon by Dashiell Hammett</li>
-                    <li>3. The Postman Always Rings Twice by James M. Cain</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                 </div>
-                </a>
               </li>
               <li data-aos="slide-right">
-                <a href="../assets/html/true-crime.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
                   <p class="card-subtitle">19</p>
                   <div class="iconrow">
@@ -5437,20 +5459,18 @@ color: #ac2127;
                     justice system through detailed and factual narratives. These stories often provide deep insights
                     into criminal minds and the complex pursuit of justice.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. In Cold Blood by Truman Capote</li>
-                    <li>2. The Devil in the White City by Erik Larson</li>
-                    <li>3. I'll Be Gone in the Dark by Michelle McNamara </li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
                 </div>
-                </a>
+
               </li>
 
               <li data-aos="zoom-int">
-                <a href="../assets/html/dystopian.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">20</p>
@@ -5464,21 +5484,18 @@ color: #ac2127;
                     oppression, deprivation, and despair. These stories challenge readers to reflect on current social
                     and political issues by presenting exaggerated consequences of modern-day problems.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. 1984 by George Orwell</li>
-                    <li>2. Fahrenheit 451 by Ray Bradbury</li>
-                    <li>3. The Handmaid's Tale by Margaret Atwood</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-                </a>
               </li>
 
               <li data-aos="slide-left">
-                <a href="../assets/html/magical-realism.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">21</p>
@@ -5492,22 +5509,19 @@ color: #ac2127;
                     of everyday life. This genre often explores the boundaries between reality and imagination, weaving
                     fantastical occurrences into the fabric of the mundane.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
-                  </p>
-                  <ul class="book-list">
-                    <li>1. The Chronicles of Narnia by C.S. Lewis</li>
-                    <li>2. Alice's Adventures in Wonderland by Lewis Carroll</li>
-                    <li>3. The Night Circus by Erin Morgenstern</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
 
                 </div>
-              </a>
               </li>
 
 
               <li data-aos="slide-right">
-                <a href="../assets/html/cyberpunk.html" style="text-decoration: none; color: inherit;">
                 <div class="chapter-card">
 
                   <p class="card-subtitle">22</p>
@@ -5522,14 +5536,138 @@ color: #ac2127;
                     technology on human life, including issues of cybernetics, artificial intelligence, and corporate
                     control.
                   </p>
-                  <p class="book-recommendation">
-                    Book Recommendations:
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
+
+                </div>
+              </li>
+
+              <li data-aos="zoom-in">
+                <div class="chapter-card">
+
+                  <p class="card-subtitle">23</p>
+                  <div class="iconrow">
+                    <h3 class="h3 card-title">Utopian</h3>
+                    <span style='font-size:5rem;filter: grayscale(100%);'>&#x1F3DD;</span>
+                  </div>
+
+                  <p class="card-text">
+                    Utopian fiction presents idealized societies where social, political, and economic conditions are
+                    perfect. These stories often explore theoretical models of how human society might function in an
+                    ideal state, offering a contrast to real-world issues and inspiring visions of a better future.
                   </p>
-                  <ul class="book-list">
-                    <li>1. Neuromancer by William Gibson</li>
-                    <li>2. Snow Crash by Neal Stephenson</li>
-                    <li>3. Altered Carbon by Richard K. Morgan</li>
-                  </ul>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
+
+                </div>
+              </li>
+
+              <li data-aos="slide-left">
+                <div class="chapter-card">
+
+                  <p class="card-subtitle">24</p>
+                  <div class="iconrow">
+                    <h3 class="h3 card-title">Experimental Fiction</h3>
+                    <span style='font-size:5rem;filter: grayscale(100%);'>&#x1F4DA;</span>
+                  </div>
+
+                  <p class="card-text">
+                    Experimental Fiction challenges conventional narrative structures and storytelling techniques. This
+                    genre is known for its innovative approaches, including fragmented narratives, unconventional
+                    formats, and metafictional elements, pushing the boundaries of traditional storytelling.
+                  </p>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
+
+                </div>
+              </li>
+
+              <li data-aos="slide-right">
+                <div class="chapter-card">
+                  <p class="card-subtitle">25</p>
+                  <div class="iconrow">
+                    <h3 class="h3 card-title">Satire</h3>
+                    <span style='font-size:5rem;filter: grayscale(100%);'>&#x1F3AD;</span>
+                  </div>
+
+                  <p class="card-text">
+                    A tribute to the visual, literary and performing arts, Satire books can give you a good laugh
+                    through verbal ingenuity, swift perception and the human understanding of sarcasm and irony in
+                    real-life.
+                  </p>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
+                </div>
+              </li>
+
+              </li>
+              <li data-aos="zoom-in">
+                <div class="chapter-card">
+
+                  <p class="card-subtitle">26</p>
+                  <div class="iconrow">
+                    <h3 class="h3 card-title">Psychological Thriller</h3>
+                    <span style='font-size:5rem;filter: grayscale(100%);'>&#x23F3;</span>
+                  </div>
+
+                  <p class="card-text">
+                    Psychological thrillers delve into the human psyche, creating suspense through mind games and
+                    unreliable narrators. They keep you guessing with twists and explore complex, often dark,
+                    motivations.
+                  </p>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
+
+                </div>
+              </li>
+
+              <li data-aos="slide-left">
+                <div class="chapter-card">
+
+                  <p class="card-subtitle">27</p>
+
+                  <h3 class="h3 card-title">Autobiography</h3>
+
+                  <p class="card-text">
+                    A non-fiction account of a person's life written by that person, offering personal insight and
+                    reflection on their experiences.It serves as a means for the author to share their unique narrative,
+                    including the challenges they've faced and the lessons they've learned along the way.
+                  </p>
+                  <a href="../assets/html/fantasy.html" class="cta2 style-9">
+                      <span style="font-size: 1.2rem;">Book Recommendations</span>
+                      <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
+                        <path d="M1,5 L11,5"></path>
+                        <polyline points="8 1 12 5 8 9"></polyline>
+                      </svg>
+                    </a>
+                </div>
+              </li>
+            </ul>
 
                 </div>
                 </a>

--- a/repo_structure.txt
+++ b/repo_structure.txt
@@ -11,6 +11,9 @@
 ├── Mystical-fantaies.html
 ├── README.md
 ├── SECURITY.md
+├── activity.css
+├── activity.html
+├── activity.js
 ├── address.css
 ├── address.html
 ├── assets/
@@ -112,12 +115,17 @@
 │   │   ├── bookpref.html
 │   │   ├── borrow.html
 │   │   ├── checkout.html
+│   │   ├── classic.html
 │   │   ├── comedy.html
 │   │   ├── comsp.html
 │   │   ├── custom.html
+│   │   ├── cyberpunk.html
 │   │   ├── detective-fiction.html
 │   │   ├── donate.html
+│   │   ├── dystopian.html
 │   │   ├── event.html
+│   │   ├── experimental-fiction.html
+│   │   ├── fairytale.html
 │   │   ├── fantasy.html
 │   │   ├── forgot-pass.html
 │   │   ├── freeBooks.html
@@ -128,16 +136,20 @@
 │   │   ├── image.png
 │   │   ├── img.png
 │   │   ├── login.html
+│   │   ├── magical-realism.html
 │   │   ├── maha.html
 │   │   ├── map.html
 │   │   ├── midnight.html
 │   │   ├── mood.html
 │   │   ├── mylogin.html
+│   │   ├── mythology.html
 │   │   ├── ngo.html
+│   │   ├── noir.html
 │   │   ├── nonfiction.html
 │   │   ├── philosophy.html
 │   │   ├── poetry.html
 │   │   ├── profileedit.html
+│   │   ├── psycological-thriller.html
 │   │   ├── quiz.html
 │   │   ├── quizzes.html
 │   │   ├── ram.html
@@ -145,13 +157,16 @@
 │   │   ├── read.html
 │   │   ├── read_later.html
 │   │   ├── romance.html
+│   │   ├── satire.html
 │   │   ├── school.html
 │   │   ├── science-fiction.html
 │   │   ├── self-help.html
 │   │   ├── social.html
 │   │   ├── suspense-thriller.html
 │   │   ├── tips.html
-│   │   └── top10.html
+│   │   ├── top10.html
+│   │   ├── true-crime.html
+│   │   └── utopian.html
 │   ├── images/
 │   │   ├── 1984.jpg
 │   │   ├── FB icon.png
@@ -230,6 +245,7 @@
 │   │   ├── ctc5.png
 │   │   ├── darkmode_bg.png
 │   │   ├── dracula.webp
+│   │   ├── dune.jpg
 │   │   ├── duno.jpeg
 │   │   ├── duno.jpg
 │   │   ├── edit profile.jpg
@@ -451,7 +467,6 @@
 ├── chat.css
 ├── chat.html
 ├── chat.js
-├── classic-literature.html
 ├── cod.jpg
 ├── comsp.html
 ├── connectWithsame.html


### PR DESCRIPTION
# Related Issue
Working on #4549 

Fixes:  #4548 

# Description

Since different pages have been created for specific genre of books, I have removed the recommended books written in text (in genre section of home pg) and replaced them with buttons leading to pages consisting of diff genre of books. (works in both light and dark mode)

(I have repeated the same link for pages that dont exist currently but are wip)

<!---give the issue number you fixed----->

# Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

# Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes. Make sure to attach before & after screenshots in your PR.]



before:
![image](https://github.com/user-attachments/assets/72370e55-b0ca-4116-9bee-05f178530abb)

after:
![image](https://github.com/user-attachments/assets/8124aac2-c190-4da6-9ddb-de10d14de4f1)
![image](https://github.com/user-attachments/assets/9e0af9dd-79f4-4fa9-bdb6-c6e843bb3a06)


# Checklist:

<!--
----Please delete options that are not relevant. And in order to tick the check box just put x inside them for example [x] like
-->

- [x] I have made this change from my own.
- [x] I have taken help from some online resources.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

