### PR TITLE
Added Favicon to Popular Books Page

### DIFF
--- a/playNow.html
+++ b/playNow.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Popular Books - SwapReads</title>
     <link rel="stylesheet" href="./assets/css/playNow.css">
+    <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon_package_v0.16/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="./assets/favicon_package_v0.16/favicon-16x16.png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 


### PR DESCRIPTION
This PR adds a favicon to the Popular Books page to enhance brand visibility and user experience.

**Changes Made**:

- Updated the HTML <head> section to include the favicon with the correct path

**Impact**: Users will now see the favicon displayed in the browser tab, improving the page's professionalism and recognizability.

fixes: #4619 

#### Result: 

#### Before:
![image](https://github.com/user-attachments/assets/d1bd4b6b-a768-4fb9-9062-1d3f846ae6e1)

#### After: 
![image](https://github.com/user-attachments/assets/63fc2fc7-df6d-46ec-b8b5-ab13a9197e1f)
