### PR TITLE
🛠️ FIX : Missing book image on ebook page

### DIFF
--- a/assets/html/freeBooks.html
+++ b/assets/html/freeBooks.html
@@ -1222,7 +1222,7 @@
           </div>
           <div class="book-item freeEbooks">
             <img
-              src="https://en.frenchpdf.com/wp-content/uploads/2020/04/Harry-Potter-and-the-Deathly-Hallows-PDF-Download_PDF-By_EnglishPDF.jpg?v=1587955879"
+              src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQxEyctF3Rw9ZoVL0pnghvW0wQfYFXjTo66QA&s"
               alt="Harry Potter and The Deathly Hallows" class="book-cover">
             <h3 class="book_title">Harry Potter and The Deathly Hallows</h3>
             <a href="https://archive.org/details/harrypotterdeath0000rowl_n2u6" class="btn btn-secondary">Download</a>


### PR DESCRIPTION

# Related Issue

 “None”

Fixes:  #4631 

# Description
The missing Book image is  fixed on Ebook page.



# Type of PR

- [x] Bug fix


# Screenshots / videos (if applicable)
![image](https://github.com/user-attachments/assets/6a815a5c-1cf9-4d59-b802-b649d3140a95)


# Checklist:



- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

