### PR TITLE
increased the font size of buy now button

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,7 +566,7 @@
         font-size: 0.8rem;
         line-height: 1.8rem;
         font-weight: 900;
-        letter-spacing: 0.25em;
+        letter-spacing: 0.15em;
         text-transform: uppercase;
         vertical-align: middle;
         color: var(--charcoal);
@@ -631,7 +631,7 @@
         font-size: 0.8rem;
         line-height: 1.8rem;
         font-weight: 900;
-        letter-spacing: 0.25em;
+        letter-spacing: 0.15em;
         text-transform: uppercase;
         vertical-align: middle;
         color: var(--charcoal);
@@ -704,7 +704,7 @@
             font-size: 0.8rem;
             line-height: 1.8rem;
             font-weight: 900;
-            letter-spacing: 0.25em;
+            letter-spacing: 0.15em;
             text-transform: uppercase;
             vertical-align: middle;
             color: var(--charcoal);
@@ -4845,7 +4845,7 @@ color: #ac2127;
                       cost (Limited Offer)
                     </p>
                     <a href="assets/html/checkout.html" class="cta1 style-9">
-                      <span style="position: relative; top: 2.7rem; font-size: 1rem;">Buy Now</span>
+                      <span style="position: relative; top: 2.7rem; font-size: 15px;">Buy Now</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
                         <polyline points="8 1 12 5 8 9"></polyline>
@@ -4863,7 +4863,7 @@ color: #ac2127;
                       timeless stories.
                     </p>
                     <a href="assets/html/checkout.html" class="cta1 style-9">
-                      <span style="position: relative; top: 2.7rem; font-size: 1rem;">Buy Now</span>
+                      <span style="position: relative; top: 2.7rem; font-size: 15px;">Buy Now</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
                         <polyline points="8 1 12 5 8 9"></polyline>
@@ -4881,7 +4881,7 @@ color: #ac2127;
                       of their original cost.
                     </p>
                     <a href="assets/html/checkout.html" class="cta1 style-9">
-                      <span style="position: relative; top: 2.7rem; font-size: 1rem;">Buy Now</span>
+                      <span style="position: relative; top: 2.7rem; font-size: 15px;">Buy Now</span>
                       <svg width="1.3rem" height="1rem" viewBox="0 0 13 10">
                         <path d="M1,5 L11,5"></path>
                         <polyline points="8 1 12 5 8 9"></polyline>


### PR DESCRIPTION
# Related Issue

None

Fixes:  #4646 

# Description

Increased the font size of buy now button which now looks better as empty space is reduced and since it is bigger it will push customer to click on it.

<!---#4646----->

# Type of PR

- [x] Feature enhancement

# Screenshots / videos (if applicable)
Before:
![Screenshot (97)](https://github.com/user-attachments/assets/36e6471b-d487-4334-9e00-7efd1fd670ee)

After:
![Screenshot (98)](https://github.com/user-attachments/assets/05f427af-9143-4dfa-9056-e017c60acc5d)


# Checklist:


- [x] I have made this change from my own.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers and screenshots after making the changes.

